### PR TITLE
Default page size typo

### DIFF
--- a/pkg/globals/collector.go
+++ b/pkg/globals/collector.go
@@ -1,7 +1,7 @@
 package globals
 
 const (
-	DefaultK8sAPIPageSize           int64 = 5000
+	DefaultK8sAPIPageSize           int64 = 500
 	DefaultK8sAPIPageBufferSize     int32 = 10
 	DefaultK8sAPIRateLimitPerSecond int   = 100
 )


### PR DESCRIPTION
Roll back to default page size:
* https://github.com/kubernetes/client-go/blob/master/tools/pager/pager.go