### PR TITLE
Add Jupyter Notebook Viz

### DIFF
--- a/deployments/kubehound/notebook/KubeHound.ipynb
+++ b/deployments/kubehound/notebook/KubeHound.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "%%gremlin\n",
-    "g.V().hasLabel(\"Volume\").repeat(out().simplePath()).until(hasLabel(\"Identity\")).path().by(valueMap())"
+    "g.V().hasLabel(\"Volume\").repeat(out().simplePath()).until(hasLabel(\"Identity\")).path().by(valueMap(\"class\", \"name\"))"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "outputs": [],
    "source": [
     "%%gremlin\n",
-    "g.V().hasLabel(\"Container\").repeat(out().simplePath()).until(hasLabel(\"Node\")).path().by(valueMap())"
+    "g.V().hasLabel(\"Container\").repeat(out().simplePath()).until(hasLabel(\"Node\")).path().by(valueMap(\"class\", \"name\"))"
    ]
   },
   {
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Paths from container to any critical asset"
+    "## Paths from container to any critical asset in less than 5 hops"
    ]
   },
   {
@@ -83,7 +83,7 @@
    "outputs": [],
    "source": [
     "%%gremlin\n",
-    "g.V().hasLabel(\"Container\").repeat(out().simplePath()).until(has(\"critical\", true)).path().by(valueMap())"
+    "g.V().hasLabel(\"Container\").repeat(out().simplePath()).until(has(\"critical\", true)).limit(5).path().by(valueMap(\"class\", \"name\"))"
    ]
   }
  ],


### PR DESCRIPTION
To test locally, run: 
```
cd deployments/kubehound/
docker compose up --build
```
Open `http://127.0.0.1:8888/`, use "admin" as the password


There are 2 different `.ipynb`:
- `KubeHound.ipynb`: contains the default provided rules, this should be concidered basically as a read only file (so we are sure the file is always ready to be used / in a clean state)
- `shared/*`: contains user notebooks, it's mounted as a volume, so user can modify and saves their update.


Question for @jt-dd: In which docker compose should I put this? All ? only the base ? only dev ? only prod ?

Notes:
I can't import the Docker image as is because it's not hosted anywhere publicly as far as I can tell, so we have to rebuild it ourselves. (https://github.com/aws/graph-notebook/blob/main/Dockerfile)