### PR TITLE
Fix non sudo Makefile system-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,15 +42,12 @@ ifneq (${DD_API_KEY},)
 endif
 
 UNAME_S := $(shell uname -s)
-ifndef DOCKER_CMD
-	ifeq ($(UNAME_S),Linux)
-		# https://docs.github.com/en/actions/learn-github-actions/variables
-		ifneq (${CI},true)
-			DOCKER_CMD := sudo docker
-		endif
+DOCKER_CMD := docker
+ifeq ($(UNAME_S),Linux)
+	# https://docs.github.com/en/actions/learn-github-actions/variables
+	ifneq (${CI},true)
+		DOCKER_CMD := sudo docker
 	endif
-else
-	DOCKER_CMD := ${DOCKER_CMD}
 endif
 
 RACE_FLAG_SYSTEM_TEST := "-race"


### PR DESCRIPTION
The `DOCKER_CMD` was always set to docker previous to checking its value