### PR TITLE
add a couple of references and expand k to kubectl

### DIFF
--- a/docs/reference/attacks/POD_EXEC.md
+++ b/docs/reference/attacks/POD_EXEC.md
@@ -32,7 +32,7 @@ See the [example pod spec](https://github.com/DataDog/KubeHound/tree/main/test/s
 Simply ask kubectl:
 
 ```bash
-k auth can-i create pod/exec
+kubectl auth can-i create pod/exec
 ```
 
 ## Exploitation
@@ -40,7 +40,7 @@ k auth can-i create pod/exec
 Spawn a new interactive shell on the target pod:
 
 ```bash
-k exec  --stdin --tty <POD NAME> -- /bin/bash
+kubectl exec  --stdin --tty <POD NAME> -- /bin/bash
 ```
 
 ## Defences

--- a/docs/reference/attacks/ROLE_BIND.md
+++ b/docs/reference/attacks/ROLE_BIND.md
@@ -82,3 +82,5 @@ Creating `(Cluster)RoleBinding` is a very powerful privilege and should not be r
 
 + [Official Kubernetes Documentation:Using RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding)
 + [Securing Kubernetes Clusters by Eliminating Risky Permissions](https://www.cyberark.com/resources/threat-research-blog/securing-kubernetes-clusters-by-eliminating-risky-permissions)
++ [Getting into a bind with Kubernetes](https://raesene.github.io/blog/2021/01/16/Getting-Into-A-Bind-with-Kubernetes/)
++ [Official Kubernetes Documentation: Bind verb](https://kubernetes.io/docs/concepts/security/rbac-good-practices/#bind-verb)

--- a/docs/reference/attacks/TOKEN_LIST.md
+++ b/docs/reference/attacks/TOKEN_LIST.md
@@ -62,3 +62,4 @@ Listing secrets is a very powerful privilege and should not be required by the m
 
 + [Official Kubernetes documentation: Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#working-with-secrets)
 + [Securing Kubernetes Clusters by Eliminating Risky Permissions](https://www.cyberark.com/resources/threat-research-blog/securing-kubernetes-clusters-by-eliminating-risky-permissions)
++ [Official Kubernetes documentation: List Secret Risks](https://kubernetes.io/docs/concepts/security/rbac-good-practices/#listing-secrets)


### PR DESCRIPTION
Adds a couple of references to the official k8s documentation and a blog for two of the attacks, also suggest expanding `k` to `kubectl` in a code block in case users don't have that shortcut mapped.