### PR TITLE
[ASENG-868] Implement StopOnError config for graph building

### DIFF
--- a/pkg/config/builder.go
+++ b/pkg/config/builder.go
@@ -9,6 +9,8 @@ const (
 
 	DefaultVertexBatchSize      = 500
 	DefaultVertexBatchSizeSmall = DefaultVertexBatchSize / 5
+
+	DefaultStopOnError = false
 )
 
 // VertexBuilderConfig configures vertex builder parameters.
@@ -29,6 +31,7 @@ type EdgeBuilderConfig struct {
 }
 
 type BuilderConfig struct {
-	Vertex VertexBuilderConfig `mapstructure:"vertex"` // Vertex builder config
-	Edge   EdgeBuilderConfig   `mapstructure:"edge"`   // Edge builder config
+	Vertex      VertexBuilderConfig `mapstructure:"vertex"`        // Vertex builder config
+	Edge        EdgeBuilderConfig   `mapstructure:"edge"`          // Edge builder config
+	StopOnError bool                `mapstructure:"stop_on_error"` // Stop the building of the graph on error
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -86,6 +86,7 @@ func SetDefaultValues(c *viper.Viper) {
 	c.SetDefault("builder.edge.batch_size", DefaultEdgeBatchSize)
 	c.SetDefault("builder.edge.batch_size_small", DefaultEdgeBatchSizeSmall)
 	c.SetDefault("builder.edge.batch_size_cluster_impact", DefaultEdgeBatchSizeClusterImpact)
+	c.SetDefault("builder.stop_on_error", DefaultStopOnError)
 }
 
 // SetEnvOverrides enables environment variable overrides for the config.

--- a/pkg/kubehound/graph/builder.go
+++ b/pkg/kubehound/graph/builder.go
@@ -96,7 +96,7 @@ func (b *Builder) buildMutating(ctx context.Context, l *log.KubehoundLogger, oic
 			// In case we don't want to continue and have a partial graph built, we return an error.
 			// This then fails the WaitForComplete early and bubbles up to main.
 			if b.cfg.Builder.StopOnError {
-				return err
+				return fmt.Errorf("building mutating edge %s: %w", label, err)
 			}
 			// Otherwise, by returning nil AND printing an error, we explicitly tell the user that something is going wrong.
 			// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
@@ -104,7 +104,7 @@ func (b *Builder) buildMutating(ctx context.Context, l *log.KubehoundLogger, oic
 			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
 			l.Errorf("Failed to create a mutating edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
 
-			return fmt.Errorf("building mutating edge %s: %w", label, err)
+			return nil
 		}
 	}
 
@@ -166,7 +166,7 @@ func (b *Builder) buildDependent(ctx context.Context, l *log.KubehoundLogger, oi
 			// In case we don't want to continue and have a partial graph built, we return an error.
 			// This then fails the WaitForComplete early and bubbles up to main.
 			if b.cfg.Builder.StopOnError {
-				return err
+				return fmt.Errorf("building dependent edge %s: %w", label, err)
 			}
 			// Otherwise, by returning nil AND printing an error, we explicitly tell the user that something is going wrong.
 			// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
@@ -174,7 +174,7 @@ func (b *Builder) buildDependent(ctx context.Context, l *log.KubehoundLogger, oi
 			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
 			l.Errorf("Failed to create a dependent edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
 
-			return fmt.Errorf("building dependent edge %s: %w", label, err)
+			return nil
 		}
 	}
 

--- a/pkg/kubehound/graph/builder.go
+++ b/pkg/kubehound/graph/builder.go
@@ -103,6 +103,7 @@ func (b *Builder) buildMutating(ctx context.Context, l *log.KubehoundLogger, oic
 			// values to the user (permissions of the users etc...)
 			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
 			l.Errorf("Failed to create a mutating edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
+
 			return fmt.Errorf("building mutating edge %s: %w", label, err)
 		}
 	}
@@ -141,6 +142,7 @@ func (b *Builder) buildSimple(ctx context.Context, l *log.KubehoundLogger, oic *
 				// values to the user (permissions of the users etc...)
 				// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
 				l.Errorf("Failed to create a simple edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
+
 				return nil
 			}
 
@@ -171,6 +173,7 @@ func (b *Builder) buildDependent(ctx context.Context, l *log.KubehoundLogger, oi
 			// values to the user (permissions of the users etc...)
 			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
 			l.Errorf("Failed to create a dependent edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
+
 			return fmt.Errorf("building dependent edge %s: %w", label, err)
 		}
 	}

--- a/pkg/kubehound/graph/builder.go
+++ b/pkg/kubehound/graph/builder.go
@@ -93,6 +93,16 @@ func (b *Builder) buildMutating(ctx context.Context, l *log.KubehoundLogger, oic
 	for label, e := range b.edges.Mutating() {
 		err := b.buildEdge(ctx, label, e, oic, l)
 		if err != nil {
+			// In case we don't want to continue and have a partial graph built, we return an error.
+			// This then fails the WaitForComplete early and bubbles up to main.
+			if b.cfg.Builder.StopOnError {
+				return err
+			}
+			// Otherwise, by returning nil AND printing an error, we explicitly tell the user that something is going wrong.
+			// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
+			// values to the user (permissions of the users etc...)
+			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
+			l.Errorf("Failed to create a mutating edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
 			return fmt.Errorf("building mutating edge %s: %w", label, err)
 		}
 	}
@@ -121,8 +131,17 @@ func (b *Builder) buildSimple(ctx context.Context, l *log.KubehoundLogger, oic *
 			err := b.buildEdge(workCtx, label, e, oic, l)
 			if err != nil {
 				l.Errorf("building simple edge %s: %v", label, err)
-
-				return err
+				// In case we don't want to continue and have a partial graph built, we return an error.
+				// This then fails the WaitForComplete early and bubbles up to main.
+				if b.cfg.Builder.StopOnError {
+					return err
+				}
+				// Otherwise, by returning nil AND printing an error, we explicitly tell the user that something is going wrong.
+				// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
+				// values to the user (permissions of the users etc...)
+				// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
+				l.Errorf("Failed to create a simple edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
+				return nil
 			}
 
 			return nil
@@ -142,6 +161,16 @@ func (b *Builder) buildDependent(ctx context.Context, l *log.KubehoundLogger, oi
 	for label, e := range b.edges.Dependent() {
 		err := b.buildEdge(ctx, label, e, oic, l)
 		if err != nil {
+			// In case we don't want to continue and have a partial graph built, we return an error.
+			// This then fails the WaitForComplete early and bubbles up to main.
+			if b.cfg.Builder.StopOnError {
+				return err
+			}
+			// Otherwise, by returning nil AND printing an error, we explicitly tell the user that something is going wrong.
+			// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
+			// values to the user (permissions of the users etc...)
+			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
+			l.Errorf("Failed to create a dependent edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
 			return fmt.Errorf("building dependent edge %s: %w", label, err)
 		}
 	}


### PR DESCRIPTION
This PR propose a fix for #144 by adding a config to allow continuing building the graph even after there are some errors.
The default config is to continue on error, but print error message.

The long term solution will be to add an error handling module that tracks and display the error, criticality and source of the issues in a human readable way.

The error message should be very explicit that it may create an incomplete graph and thus cause inaccurate (false negative) results.