### PR TITLE
[DOC] Add link to example queries doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ To query the KubeHound graph data requires using the [Gremlin](https://tinkerpop
 + Create a connection to the local janusgraph instance by following the steps here https://docs.gdotv.com/connection-management/ and using `hostname=localhost`
 + Navigate to the query editor and enter a sample query e.g `g.V().count()`. See detailed instructions here: https://docs.gdotv.com/query-editor/#run-your-query
 
+### Example queries
+
+We have documented a few sample queries to execute on the database in [our documentation](https://kubehound.io/queries/gremlin/).
+
 ### Query data from your scripts
 
 #### Python


### PR DESCRIPTION
Add a simple link to the example queries so it's easier to find.

This should fix or at least help a bit with https://github.com/DataDog/KubeHound/issues/152