### PR TITLE
Fix-tag-race-condition

### DIFF
--- a/cmd/kubehound-ingestor/main.go
+++ b/cmd/kubehound-ingestor/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+	"github.com/DataDog/KubeHound/pkg/telemetry/tag"
 )
 
 func main() {
+	tag.SetupBaseTags()
 	if err := rootCmd.Execute(); err != nil {
 		log.I.Fatal(err.Error())
 	}

--- a/cmd/kubehound/main.go
+++ b/cmd/kubehound/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+	"github.com/DataDog/KubeHound/pkg/telemetry/tag"
 )
 
 func main() {
+	tag.SetupBaseTags()
 	if err := rootCmd.Execute(); err != nil {
 		log.I.Fatal(err.Error())
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -83,7 +83,7 @@ type EndpointIngestor interface {
 }
 
 //go:generate mockery --name CollectorClient --output mockcollector --case underscore --filename collector_client.go --with-expecter
-type CollectorClient interface { //nolint: interfacebloat
+type CollectorClient interface {
 	services.Dependency
 
 	// ClusterInfo returns the target cluster information for the current run.

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -83,11 +83,14 @@ type EndpointIngestor interface {
 }
 
 //go:generate mockery --name CollectorClient --output mockcollector --case underscore --filename collector_client.go --with-expecter
-type CollectorClient interface {
+type CollectorClient interface { //nolint: interfacebloat
 	services.Dependency
 
 	// ClusterInfo returns the target cluster information for the current run.
 	ClusterInfo(ctx context.Context) (*ClusterInfo, error)
+
+	// Tags return the tags for the current run.
+	Tags(ctx context.Context) []string
 
 	// StreamNodes will iterate through all NodeType objects collected by the collector and invoke the ingestor.IngestNode method on each.
 	// Once all the NodeType objects have been exhausted the ingestor.Complete method will be invoked to signal the end of the stream.

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/KubeHound/pkg/config"
 	"github.com/DataDog/KubeHound/pkg/globals/types"
 	"github.com/DataDog/KubeHound/pkg/kubehound/services"
+	"github.com/DataDog/KubeHound/pkg/telemetry/tag"
 )
 
 // ClusterInfo encapsulates the target cluster information for the current run.
@@ -88,9 +89,6 @@ type CollectorClient interface { //nolint: interfacebloat
 	// ClusterInfo returns the target cluster information for the current run.
 	ClusterInfo(ctx context.Context) (*ClusterInfo, error)
 
-	// Tags return the tags for the current run.
-	Tags(ctx context.Context) []string
-
 	// StreamNodes will iterate through all NodeType objects collected by the collector and invoke the ingestor.IngestNode method on each.
 	// Once all the NodeType objects have been exhausted the ingestor.Complete method will be invoked to signal the end of the stream.
 	StreamNodes(ctx context.Context, ingestor NodeIngestor) error
@@ -132,5 +130,29 @@ func ClientFactory(ctx context.Context, cfg *config.KubehoundConfig) (CollectorC
 		return NewFileCollector(ctx, cfg)
 	default:
 		return nil, fmt.Errorf("collector type not supported: %s", cfg.Collector.Type)
+	}
+}
+
+type collectorTags struct {
+	pod                []string
+	role               []string
+	rolebinding        []string
+	endpoint           []string
+	node               []string
+	clusterrole        []string
+	clusterrolebinding []string
+	baseTags           []string
+}
+
+func newCollectorTags() *collectorTags {
+	return &collectorTags{
+		pod:                tag.GetBaseTagsWith(tag.Collector(FileCollectorName), tag.Entity(tag.EntityPods)),
+		role:               tag.GetBaseTagsWith(tag.Collector(FileCollectorName), tag.Entity(tag.EntityRoles)),
+		rolebinding:        tag.GetBaseTagsWith(tag.Collector(FileCollectorName), tag.Entity(tag.EntityRolebindings)),
+		endpoint:           tag.GetBaseTagsWith(tag.Collector(FileCollectorName), tag.Entity(tag.EntityEndpoints)),
+		node:               tag.GetBaseTagsWith(tag.Collector(FileCollectorName), tag.Entity(tag.EntityNodes)),
+		clusterrole:        tag.GetBaseTagsWith(tag.Collector(FileCollectorName), tag.Entity(tag.EntityClusterRoles)),
+		clusterrolebinding: tag.GetBaseTagsWith(tag.Collector(FileCollectorName), tag.Entity(tag.EntityClusterRolebindings)),
+		baseTags:           tag.GetBaseTags(),
 	}
 }

--- a/pkg/collector/file.go
+++ b/pkg/collector/file.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/DataDog/KubeHound/pkg/config"
 	"github.com/DataDog/KubeHound/pkg/globals"

--- a/pkg/collector/file.go
+++ b/pkg/collector/file.go
@@ -120,8 +120,7 @@ func (c *FileCollector) Close(_ context.Context) error {
 func (c *FileCollector) count(entity string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.tags = append(c.tags, tag.Entity(entity))
-	_ = statsd.Incr(metric.CollectorCount, c.tags, 1)
+	_ = statsd.Incr(metric.CollectorCount, append(c.tags, tag.Entity(entity)), 1)
 }
 
 // streamPodsNamespace streams the pod objects in a single file, corresponding to a cluster namespace.

--- a/pkg/collector/file.go
+++ b/pkg/collector/file.go
@@ -62,8 +62,6 @@ type FileCollector struct {
 
 // NewFileCollector creates a new instance of the file collector from the provided application config.
 func NewFileCollector(ctx context.Context, cfg *config.KubehoundConfig) (CollectorClient, error) {
-	tags := tag.BaseTags
-	tags = append(tags, tag.Collector(FileCollectorName))
 	if cfg.Collector.Type != config.CollectorTypeFile {
 		return nil, fmt.Errorf("invalid collector type in config: %s", cfg.Collector.Type)
 	}

--- a/pkg/collector/file.go
+++ b/pkg/collector/file.go
@@ -78,6 +78,11 @@ func NewFileCollector(ctx context.Context, cfg *config.KubehoundConfig) (Collect
 	}, nil
 }
 
+// TODO: remove this after all PR
+func (c *FileCollector) Tags(ctx context.Context) []string {
+	return nil
+}
+
 func (c *FileCollector) Name() string {
 	return FileCollectorName
 }

--- a/pkg/collector/k8s_api.go
+++ b/pkg/collector/k8s_api.go
@@ -123,6 +123,11 @@ func NewK8sAPICollector(ctx context.Context, cfg *config.KubehoundConfig) (Colle
 	}, nil
 }
 
+// TODO: remove this after all PR
+func (c *k8sAPICollector) Tags(ctx context.Context) []string {
+	return nil
+}
+
 func (c *k8sAPICollector) wait(_ context.Context, resourceType string) {
 	prev := time.Now()
 	now := c.rl.Take()

--- a/pkg/kubehound/ingestor/pipeline/ingest_resources.go
+++ b/pkg/kubehound/ingestor/pipeline/ingest_resources.go
@@ -81,7 +81,7 @@ func WithConverterCache() IngestResourceOption {
 // To access the writer use the storeWriter(c collections.Collection) function.
 func WithStoreWriter[T collections.Collection](c T) IngestResourceOption {
 	return func(ctx context.Context, rOpts *resourceOptions, deps *Dependencies) error {
-		w, err := deps.StoreDB.BulkWriter(ctx, c, storedb.WithTags(tag.BaseTags))
+		w, err := deps.StoreDB.BulkWriter(ctx, c, storedb.WithTags(tag.GetBaseTags()))
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func WithGraphWriter(v vertex.Builder) IngestResourceOption {
 			return err
 		}
 
-		w, err := deps.GraphDB.VertexWriter(ctx, v, deps.Cache, graphdb.WithTags(tag.BaseTags))
+		w, err := deps.GraphDB.VertexWriter(ctx, v, deps.Cache, graphdb.WithTags(tag.GetBaseTags()))
 		if err != nil {
 			return err
 		}

--- a/pkg/kubehound/storage/cache/memcache_provider.go
+++ b/pkg/kubehound/storage/cache/memcache_provider.go
@@ -53,11 +53,12 @@ func (m *MemCacheProvider) Get(ctx context.Context, key cachekey.CacheKey) *Cach
 	defer m.mu.RUnlock()
 	var err error
 	data, ok := m.data[computeKey(key)]
+	tagCacheKey := tag.GetBaseTagsWith(tag.CacheKey(key.Shard()))
 	if !ok {
-		_ = statsd.Incr(metric.CacheMiss, append(tag.BaseTags, tag.CacheKey(key.Shard())), 1)
+		_ = statsd.Incr(metric.CacheMiss, tagCacheKey, 1)
 		log.Trace(ctx).Debugf("entry not found in cache: %s", computeKey(key))
 	} else {
-		_ = statsd.Incr(metric.CacheHit, append(tag.BaseTags, tag.CacheKey(key.Shard())), 1)
+		_ = statsd.Incr(metric.CacheHit, tagCacheKey, 1)
 	}
 
 	return &CacheResult{

--- a/pkg/kubehound/storage/graphdb/janusgraph_provider.go
+++ b/pkg/kubehound/storage/graphdb/janusgraph_provider.go
@@ -47,7 +47,7 @@ func NewGraphDriver(ctx context.Context, cfg *config.KubehoundConfig) (*JanusGra
 	jgp := &JanusGraphProvider{
 		cfg:  cfg,
 		drc:  driver,
-		tags: append(tag.BaseTags, tag.Storage(StorageProviderName)),
+		tags: tag.GetBaseTagsWith(tag.Storage(StorageProviderName)),
 	}
 
 	return jgp, nil

--- a/pkg/kubehound/storage/storedb/mongo_provider.go
+++ b/pkg/kubehound/storage/storedb/mongo_provider.go
@@ -80,7 +80,7 @@ func NewMongoProvider(ctx context.Context, cfg *config.KubehoundConfig) (*MongoP
 	return &MongoProvider{
 		reader: reader,
 		writer: writer,
-		tags:   append(tag.BaseTags, tag.Storage(StorageProviderName)),
+		tags:   tag.GetBaseTagsWith(tag.Storage(StorageProviderName)),
 	}, nil
 }
 

--- a/pkg/telemetry/profiler/profiler.go
+++ b/pkg/telemetry/profiler/profiler.go
@@ -27,7 +27,7 @@ func Initialize(cfg *config.KubehoundConfig) {
 		profiler.WithPeriod(cfg.Telemetry.Profiler.Period),
 		profiler.CPUDuration(cfg.Telemetry.Profiler.CPUDuration),
 		profiler.WithLogStartup(false),
-		profiler.WithTags(tag.BaseTags...),
+		profiler.WithTags(tag.GetBaseTags()...),
 	)
 	if err != nil {
 		log.I.Errorf("start profiler: %v", err)

--- a/pkg/telemetry/statsd/statsd.go
+++ b/pkg/telemetry/statsd/statsd.go
@@ -33,7 +33,7 @@ func Setup(cfg *config.KubehoundConfig) error {
 
 		return nil
 	}
-	tags := tag.BaseTags
+	tags := tag.GetBaseTags()
 	for tk, tv := range cfg.Telemetry.Tags {
 		tags = append(tags, tag.MakeTag(tk, tv))
 	}

--- a/pkg/telemetry/tag/tags.go
+++ b/pkg/telemetry/tag/tags.go
@@ -39,11 +39,6 @@ const (
 	EntityClusterRolebindings = "clusterrolebindings"
 )
 
-// TODO: delete it once PR merged
-var (
-	BaseTags = []string{}
-)
-
 type BasesTags struct {
 	mu   sync.Mutex
 	tags []string

--- a/pkg/telemetry/tracer/tracer.go
+++ b/pkg/telemetry/tracer/tracer.go
@@ -23,7 +23,7 @@ func Initialize(cfg *config.KubehoundConfig) {
 	}
 
 	// Add the base tags
-	for _, t := range tag.BaseTags {
+	for _, t := range tag.GetBaseTags() {
 		const tagSplitLen = 2
 		split := strings.Split(t, ":")
 		if len(split) != tagSplitLen {


### PR DESCRIPTION
During the system stumbled on a race condition in the tags. This bug is triggered when the slice for the tags grows enough that it requires a new allocation.
This fix should prevent most of the race condition. 

Ref: https://medium.com/@cep21/gos-append-is-not-always-thread-safe-a3034db7975