### PR TITLE
Refactor writers (multi-thread + enveloped k8s type_

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,5 +40,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
-          version: v1.53.1
+          version: v1.56.2
           args: ./...

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,5 +40,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
-          version: v4.0.0
+          version: v1.53.1
           args: ./...

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Checkout Git Repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,5 +40,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
-          version: v1.53.1
+          version: v4.0.0
           args: ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Run GoReleaser
         timeout-minutes: 60

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Run integration Tests
         run: make system-test

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: "1.20"
+          go-version: "1.22"
        
       - name: Checkout Git Repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/KubeHound
 
-go 1.20
+go 1.22
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.3.0
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.25.5
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.44.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/spf13/afero v1.10.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.4
 	go.mongodb.org/mongo-driver v1.12.1
@@ -109,7 +110,6 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	github.com/spf13/afero v1.10.0 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKP
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPTY=
 cloud.google.com/go v0.110.10 h1:LXy9GEO+timppncPIAZoOj3l58LIU9k+kn48AN7IO3Y=
+cloud.google.com/go v0.110.10/go.mod h1:v1OoFqYxiBkUrruItNM3eT4lLByNjxmJSV/xDKJNnic=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -25,10 +26,13 @@ cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUM
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/compute v1.23.3 h1:6sVlXXBmbd7jNX0Ipq0trII3e4n1/MsADLK6a+aiVlk=
+cloud.google.com/go/compute v1.23.3/go.mod h1:VCgBUoMnIVIR0CscqQiPJLAG25E3ZRZMzcFZeQ+h8CI=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/iam v1.1.5 h1:1jTsCu4bcsNsE4iiqNT5SHwrDRCfRmIaaaVFhRveTJI=
+cloud.google.com/go/iam v1.1.5/go.mod h1:rB6P/Ic3mykPbFio+vo7403drjlgvoWfYpJhMXEbzv8=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
@@ -40,6 +44,7 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 cloud.google.com/go/storage v1.35.1 h1:B59ahL//eDfx2IIKFBeT5Atm9wnNmj3+8xG/W4WB//w=
+cloud.google.com/go/storage v1.35.1/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
@@ -152,6 +157,7 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -161,6 +167,7 @@ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/zapr v1.2.4 h1:QHVo+6stLbfJmYGkQ7uGHUCu5hnAFAj6mDe6Ea0SeOo=
+github.com/go-logr/zapr v1.2.4/go.mod h1:FyHWQIzQORZ0QVE1BtVHv3cKtNLuXsbNLtpuhNapBOA=
 github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE=
@@ -168,6 +175,7 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -223,7 +231,9 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-replayers/grpcreplay v1.1.0 h1:S5+I3zYyZ+GQz68OfbURDdt/+cSMqCK1wrvNx7WBzTE=
+github.com/google/go-replayers/grpcreplay v1.1.0/go.mod h1:qzAvJ8/wi57zq7gWqaE6AwLM6miiXUQwP1S+I9icmhk=
 github.com/google/go-replayers/httpreplay v1.2.0 h1:VM1wEyyjaoU53BwrOnaf9VhAyQQEEioJvFYxYcLRKzk=
+github.com/google/go-replayers/httpreplay v1.2.0/go.mod h1:WahEFFZZ7a1P4VM1qEeHy+tME4bwyqPcwWbNlUI1Mcg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
@@ -233,6 +243,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -247,6 +258,7 @@ github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b h1:h9U78+dx9a4BKdQkBB
 github.com/google/pprof v0.0.0-20230817174616-7a8ec2ada47b/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
+github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
@@ -254,6 +266,7 @@ github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/wire v0.5.0 h1:I7ELFeVBr3yfPIcc8+MWvrjk+3VjbcSzoXm3JVa+jD8=
 github.com/google/wire v0.5.0/go.mod h1:ngWDr9Qvq3yZA10YrxfyGELY/AFWGVpy9c1LTRi1EoU=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
+github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
@@ -297,6 +310,7 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -324,8 +338,11 @@ github.com/nicksnyder/go-i18n/v2 v2.2.1/go.mod h1:fF2++lPHlo+/kPaj3nB0uxtPwzlPm+
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/onsi/ginkgo/v2 v2.9.5 h1:+6Hr4uxzP4XIUyAkg61dWBw8lb/gc4/X5luuxN/EC+Q=
+github.com/onsi/ginkgo/v2 v2.9.5/go.mod h1:tvAoo1QUJwNEU2ITftXTpR7R1RbCzoZUOs3RonqW57k=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
+github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/outcaste-io/ristretto v0.2.1/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
 github.com/outcaste-io/ristretto v0.2.3 h1:AK4zt/fJ76kjlYObOeNwh4T3asEuaCmp26pOvUOL9w0=
 github.com/outcaste-io/ristretto v0.2.3/go.mod h1:W8HywhmtlopSB1jeMg3JtdIhf+DYkLAr0VN/s4+MHac=
@@ -354,6 +371,7 @@ github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 h1:Qp27Id
 github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052/go.mod h1:uvX/8buq8uVeiZiFht+0lqSLBHF+uGV8BrTv8W/SIwk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.3.0 h1:zT7VEGWC2DTflmccN/5T1etyKvxSxpHsjb9cJvm4SvQ=
 github.com/sagikazarmark/locafero v0.3.0/go.mod h1:w+v7UsPNFwzF1cHuOajOOzoq4U7v/ig1mpRjqV+Bu1U=
@@ -429,11 +447,13 @@ go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
 go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
+go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
 go4.org/intern v0.0.0-20230525184215-6c62f75575cb h1:ae7kzL5Cfdmcecbh22ll7lYP3iuUdnfnhiPcSaDgH/8=
 go4.org/intern v0.0.0-20230525184215-6c62f75575cb/go.mod h1:Ycrt6raEcnF5FTsLiLKkhBTO6DPX3RCUCUVnks3gFJU=
@@ -757,7 +777,9 @@ google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20231120223509-83a465c0220f h1:Vn+VyHU5guc9KjB5KrjI2q0wCOWEOIh0OEsleqakHJg=
+google.golang.org/genproto v0.0.0-20231120223509-83a465c0220f/go.mod h1:nWSwAFPb+qfNJXsoeO3Io7zf4tMSfN8EA8RlDA04GhY=
 google.golang.org/genproto/googleapis/api v0.0.0-20231120223509-83a465c0220f h1:2yNACc1O40tTnrsbk9Cv6oxiW8pxI/pXj0wRtdlYmgY=
+google.golang.org/genproto/googleapis/api v0.0.0-20231120223509-83a465c0220f/go.mod h1:Uy9bTZJqmfrw2rIBxgGLnamc78euZULUBrLZ9XTITKI=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f h1:ultW7fxlIvee4HYrtnaRPon9HpEgFk5zYpmfMgtKB5I=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f/go.mod h1:L9KNLi232K1/xB6f7AlSX692koaRnKaWSR0stBki0Yc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/pkg/dump/writer/file_writer.go
+++ b/pkg/dump/writer/file_writer.go
@@ -1,9 +1,9 @@
 package writer
 
 import (
-	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
 	"github.com/DataDog/KubeHound/pkg/telemetry/span"
 	"github.com/DataDog/KubeHound/pkg/telemetry/tag"
+	"github.com/spf13/afero"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
@@ -29,16 +30,21 @@ const (
 // The FileWriter uses a map of buffers to write data to files
 // Each file has its own buffer to optimize IO calls
 type FileWriter struct {
-	files           map[string]*os.File
 	directoryOutput string
 	mu              sync.Mutex
+	fsWriter        *FSWriter
 }
 
 func NewFileWriter(ctx context.Context, directoryOutput string, resName string) (*FileWriter, error) {
+	fsWriter, err := NewFSWriter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("creating fs writer: %w", err)
+	}
+
 	return &FileWriter{
-		files:           make(map[string]*os.File),
-		directoryOutput: path.Join(directoryOutput, resName),
+		directoryOutput: directoryOutput,
 		mu:              sync.Mutex{},
+		fsWriter:        fsWriter,
 	}, nil
 }
 
@@ -52,40 +58,50 @@ func (f *FileWriter) WorkerNumber() int {
 
 // Write function writes the Kubernetes object to a buffer
 // All buffer are stored in a map which is flushed at the end of every type processed
-func (f *FileWriter) Write(ctx context.Context, k8sObj any, pathObj string) error {
+func (f *FileWriter) Write(ctx context.Context, k8sObj []byte, pathObj string) error {
 	log.I.Debugf("Writing to file %s", pathObj)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	data, err := marshalK8sObj(k8sObj)
+	// Writing file to Afero memfs
+	err := f.fsWriter.WriteFile(ctx, pathObj, k8sObj)
 	if err != nil {
-		return err
+		return fmt.Errorf("write file %s: %w", pathObj, err)
 	}
 
-	// Constructing output complete path to write the file
-	filePath := path.Join(f.directoryOutput, pathObj)
+	// Constructing output complete path to write the file on disk
+	fileDiskPath := path.Join(f.directoryOutput, pathObj)
+
+	fs := afero.NewIOFS(f.fsWriter.vfs)
+	fsAferoSource, err := f.fsWriter.vfs.OpenFile(pathObj, os.O_RDONLY, FileWriterChmod)
+	if err != nil {
+		return fmt.Errorf("open file from afero %s: %w", pathObj, err)
+	}
 
 	// Create directories if they do not exist
-	err = os.MkdirAll(filepath.Dir(filePath), WriterDirChmod)
+	err = os.MkdirAll(filepath.Dir(fileDiskPath), WriterDirMod)
 	if err != nil {
 		return fmt.Errorf("failed to create directories: %w", err)
 	}
 
-	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, FileWriterChmod)
+	fdFileDisk, err := os.Create(fileDiskPath)
 	if err != nil {
-		return fmt.Errorf("failed to open file: %w", err)
-	}
-	f.files[pathObj] = file
-	buffer := bufio.NewWriter(file)
-
-	_, err = buffer.Write(data)
-	if err != nil {
-		return fmt.Errorf("failed to write JSON data to buffer: %w", err)
+		return fmt.Errorf("create file %s: %w", pathObj, err)
 	}
 
-	err = buffer.Flush()
+	_, err = io.Copy(fdFileDisk, fsAferoSource)
 	if err != nil {
-		return fmt.Errorf("failed to flush writer: %w", err)
+		return fmt.Errorf("copy file %s: %w", pathObj, err)
+	}
+
+	err = fdFileDisk.Close()
+	if err != nil {
+		return fmt.Errorf("close file %s: %w", pathObj, err)
+	}
+
+	err = fs.Remove(pathObj)
+	if err != nil {
+		return fmt.Errorf("remove file from afero %s: %w", pathObj, err)
 	}
 
 	return nil
@@ -93,6 +109,11 @@ func (f *FileWriter) Write(ctx context.Context, k8sObj any, pathObj string) erro
 
 // No flush needed for the file writer as we are flushing the buffer at every write
 func (f *FileWriter) Flush(ctx context.Context) error {
+	span, _ := tracer.StartSpanFromContext(ctx, span.DumperWriterFlush, tracer.Measured())
+	span.SetTag(tag.DumperWriterTypeTag, FileTypeTag)
+	var err error
+	defer func() { span.Finish(tracer.WithError(err)) }()
+
 	return nil
 }
 
@@ -102,12 +123,9 @@ func (f *FileWriter) Close(ctx context.Context) error {
 	span.SetTag(tag.DumperWriterTypeTag, FileTypeTag)
 	var err error
 	defer func() { span.Finish(tracer.WithError(err)) }()
-	for path, file := range f.files {
-		err = file.Close()
-		if err != nil {
-			return fmt.Errorf("failed to close writer: %w", err)
-		}
-		delete(f.files, path)
+	err = f.fsWriter.Close(ctx)
+	if err != nil {
+		return fmt.Errorf("close afero: %w", err)
 	}
 
 	return nil

--- a/pkg/dump/writer/file_writer.go
+++ b/pkg/dump/writer/file_writer.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sync"
 
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
 	"github.com/DataDog/KubeHound/pkg/telemetry/span"
@@ -28,16 +29,16 @@ const (
 // The FileWriter uses a map of buffers to write data to files
 // Each file has its own buffer to optimize IO calls
 type FileWriter struct {
-	buffers         map[string]*bufio.Writer
 	files           map[string]*os.File
 	directoryOutput string
+	mu              sync.Mutex
 }
 
 func NewFileWriter(ctx context.Context, directoryOutput string, resName string) (*FileWriter, error) {
 	return &FileWriter{
-		buffers:         make(map[string]*bufio.Writer),
 		files:           make(map[string]*os.File),
 		directoryOutput: path.Join(directoryOutput, resName),
+		mu:              sync.Mutex{},
 	}, nil
 }
 
@@ -49,51 +50,49 @@ func (f *FileWriter) WorkerNumber() int {
 	return FileWriterWorkerNumber
 }
 
-func (f *FileWriter) Write(ctx context.Context, data []byte, filePath string) error {
-	span, _ := tracer.StartSpanFromContext(ctx, span.DumperWriterWrite, tracer.Measured())
-	span.SetTag(tag.DumperFilePathTag, filePath)
-	span.SetTag(tag.DumperWriterTypeTag, FileTypeTag)
-	defer span.Finish()
-	filePath = path.Join(f.directoryOutput, filePath)
+// Write function writes the Kubernetes object to a buffer
+// All buffer are stored in a map which is flushed at the end of every type processed
+func (f *FileWriter) Write(ctx context.Context, k8sObj any, pathObj string) error {
+	log.I.Debugf("Writing to file %s", pathObj)
+	f.mu.Lock()
+	defer f.mu.Unlock()
 
-	buffer, ok := f.buffers[filePath]
-	if !ok {
-		// Create directories if they do not exist
-		err := os.MkdirAll(filepath.Dir(filePath), WriterDirChmod)
-		if err != nil {
-			return fmt.Errorf("failed to create directories: %w", err)
-		}
-
-		file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, FileWriterChmod)
-		if err != nil {
-			return fmt.Errorf("failed to open file: %w", err)
-		}
-		f.files[filePath] = file
-		buffer = bufio.NewWriter(file)
-		f.buffers[filePath] = buffer
+	data, err := marshalK8sObj(k8sObj)
+	if err != nil {
+		return err
 	}
-	_, err := buffer.Write(data)
+
+	// Constructing output complete path to write the file
+	filePath := path.Join(f.directoryOutput, pathObj)
+
+	// Create directories if they do not exist
+	err = os.MkdirAll(filepath.Dir(filePath), WriterDirChmod)
+	if err != nil {
+		return fmt.Errorf("failed to create directories: %w", err)
+	}
+
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, FileWriterChmod)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	f.files[pathObj] = file
+	buffer := bufio.NewWriter(file)
+
+	_, err = buffer.Write(data)
 	if err != nil {
 		return fmt.Errorf("failed to write JSON data to buffer: %w", err)
+	}
+
+	err = buffer.Flush()
+	if err != nil {
+		return fmt.Errorf("failed to flush writer: %w", err)
 	}
 
 	return nil
 }
 
+// No flush needed for the file writer as we are flushing the buffer at every write
 func (f *FileWriter) Flush(ctx context.Context) error {
-	log.I.Debug("Flushing writers")
-	span, _ := tracer.StartSpanFromContext(ctx, span.DumperWriterFlush, tracer.Measured())
-	span.SetTag(tag.DumperWriterTypeTag, FileTypeTag)
-	defer span.Finish()
-	for path, writer := range f.buffers {
-		err := writer.Flush()
-		if err != nil {
-			return fmt.Errorf("failed to flush writer: %w", err)
-		}
-		delete(f.buffers, path)
-	}
-	f.buffers = make(map[string]*bufio.Writer)
-
 	return nil
 }
 
@@ -104,14 +103,12 @@ func (f *FileWriter) Close(ctx context.Context) error {
 	var err error
 	defer func() { span.Finish(tracer.WithError(err)) }()
 	for path, file := range f.files {
-		err := file.Close()
+		err = file.Close()
 		if err != nil {
 			return fmt.Errorf("failed to close writer: %w", err)
 		}
 		delete(f.files, path)
 	}
-
-	f.files = make(map[string]*os.File)
 
 	return nil
 }

--- a/pkg/dump/writer/file_writer_test.go
+++ b/pkg/dump/writer/file_writer_test.go
@@ -1,0 +1,75 @@
+package writer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+func TestFileWriter_Write(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tmpDir, err := os.MkdirTemp("/tmp/", "kh-unit-tests-*")
+	if err != nil {
+		log.I.Fatalf(err.Error())
+	}
+
+	fileNameK8sObject := collector.EndpointPath
+	dummyNamespace := "namespace1"
+	dummyK8sObject := []*discoveryv1.EndpointSlice{
+		collector.FakeEndpoint("name1", "namespace1", []int32{int32(80)}),
+		collector.FakeEndpoint("name2", "namespace1", []int32{int32(443)}),
+	}
+
+	writer, err := NewFileWriter(ctx, tmpDir, fileNameK8sObject)
+	if err != nil {
+		t.Fatalf("failed to create file writer: %v", err)
+	}
+
+	vfsResourcePath := path.Join(dummyNamespace, fileNameK8sObject)
+	diskResourcePath := path.Join(writer.OutputPath(), vfsResourcePath)
+
+	jsonData, err := json.Marshal(dummyK8sObject)
+	if err != nil {
+		t.Fatalf("failed to marshal Kubernetes object: %v", err)
+	}
+
+	err = writer.Write(ctx, jsonData, vfsResourcePath)
+	if err != nil {
+		t.Fatalf("write %s: %v", reflect.TypeOf(dummyK8sObject), err)
+	}
+
+	file, err := os.Open(diskResourcePath)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	defer file.Close()
+	readK8sObject, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+
+	var processedDummyK8sObject []*discoveryv1.EndpointSlice
+	err = json.Unmarshal(readK8sObject, &processedDummyK8sObject)
+	if err != nil {
+		t.Fatalf("failed to unmarshal Kubernetes object: %v", err)
+	}
+
+	if !reflect.DeepEqual(processedDummyK8sObject, dummyK8sObject) {
+		t.Fatalf("expected %v, got %v", processedDummyK8sObject, readK8sObject)
+	}
+
+	err = os.Remove(file.Name())
+	if err != nil {
+		t.Fatalf("failed to remove file: %v", err)
+	}
+}

--- a/pkg/dump/writer/file_writer_test.go
+++ b/pkg/dump/writer/file_writer_test.go
@@ -14,6 +14,10 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 )
 
+const (
+	dummyNamespace = "namespace1"
+)
+
 func TestFileWriter_Write(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -24,7 +28,6 @@ func TestFileWriter_Write(t *testing.T) {
 	}
 
 	fileNameK8sObject := collector.EndpointPath
-	dummyNamespace := "namespace1"
 	dummyK8sObject := []*discoveryv1.EndpointSlice{
 		collector.FakeEndpoint("name1", dummyNamespace, []int32{int32(80)}),
 		collector.FakeEndpoint("name2", dummyNamespace, []int32{int32(443)}),

--- a/pkg/dump/writer/file_writer_test.go
+++ b/pkg/dump/writer/file_writer_test.go
@@ -26,8 +26,8 @@ func TestFileWriter_Write(t *testing.T) {
 	fileNameK8sObject := collector.EndpointPath
 	dummyNamespace := "namespace1"
 	dummyK8sObject := []*discoveryv1.EndpointSlice{
-		collector.FakeEndpoint("name1", "namespace1", []int32{int32(80)}),
-		collector.FakeEndpoint("name2", "namespace1", []int32{int32(443)}),
+		collector.FakeEndpoint("name1", dummyNamespace, []int32{int32(80)}),
+		collector.FakeEndpoint("name2", dummyNamespace, []int32{int32(443)}),
 	}
 
 	writer, err := NewFileWriter(ctx, tmpDir, fileNameK8sObject)

--- a/pkg/dump/writer/file_writer_test.go
+++ b/pkg/dump/writer/file_writer_test.go
@@ -72,4 +72,13 @@ func TestFileWriter_Write(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to remove file: %v", err)
 	}
+
+	err = writer.Flush(ctx)
+	if err != nil {
+		t.Fatalf("failed to flush: %v", err)
+	}
+	err = writer.Close(ctx)
+	if err != nil {
+		t.Fatalf("failed to close: %v", err)
+	}
 }

--- a/pkg/dump/writer/fs_writer.go
+++ b/pkg/dump/writer/fs_writer.go
@@ -1,0 +1,83 @@
+package writer
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+	"github.com/DataDog/KubeHound/pkg/telemetry/span"
+	"github.com/DataDog/KubeHound/pkg/telemetry/tag"
+	"github.com/spf13/afero"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+const (
+	FSWriterChmod = 0600
+)
+
+// The FileWriter uses a map of buffers to write data to files
+// Each file has its own buffer to optimize IO calls
+type FSWriter struct {
+	mu  sync.Mutex
+	vfs afero.Fs
+}
+
+func NewFSWriter(ctx context.Context) (*FSWriter, error) {
+	return &FSWriter{
+		vfs: afero.NewMemMapFs(),
+	}, nil
+}
+
+// Write function writes the Kubernetes object to a buffer
+// All buffer are stored in a map which is flushed at the end of every type processed
+func (f *FSWriter) WriteFile(ctx context.Context, pathObj string, k8sObj []byte) error {
+	log.I.Debugf("Writing to file %s", pathObj)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Create directories if they do not exist
+	err := f.vfs.MkdirAll(filepath.Dir(pathObj), WriterDirMod)
+	if err != nil {
+		return fmt.Errorf("failed to create directories: %w", err)
+	}
+
+	err = afero.WriteFile(f.vfs, pathObj, k8sObj, FSWriterChmod)
+	if err != nil {
+		return fmt.Errorf("failed to write JSON data to file: %w", err)
+	}
+
+	// file, err := f.vfs.OpenFile(pathObj, os.O_APPEND|os.O_WRONLY|os.O_CREATE, FileWriterChmod)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to open file: %w", err)
+	// }
+	// defer file.Close()
+
+	// buffer := bufio.NewWriter(file)
+	// _, err = buffer.Write(k8sObj)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to write JSON data to buffer: %w", err)
+	// }
+
+	// err = buffer.Flush()
+	// if err != nil {
+	// 	return fmt.Errorf("failed to flush writer: %w", err)
+	// }
+
+	return nil
+}
+
+// No flush needed for the file writer as we are flushing the buffer at every write
+func (f *FSWriter) Flush(ctx context.Context) error {
+	span, _ := tracer.StartSpanFromContext(ctx, span.DumperWriterFlush, tracer.Measured())
+	span.SetTag(tag.DumperWriterTypeTag, TarTypeTag)
+	var err error
+	defer func() { span.Finish(tracer.WithError(err)) }()
+
+	return nil
+}
+
+func (f *FSWriter) Close(ctx context.Context) error {
+	return nil
+}

--- a/pkg/dump/writer/fs_writer.go
+++ b/pkg/dump/writer/fs_writer.go
@@ -48,23 +48,6 @@ func (f *FSWriter) WriteFile(ctx context.Context, pathObj string, k8sObj []byte)
 		return fmt.Errorf("failed to write JSON data to file: %w", err)
 	}
 
-	// file, err := f.vfs.OpenFile(pathObj, os.O_APPEND|os.O_WRONLY|os.O_CREATE, FileWriterChmod)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to open file: %w", err)
-	// }
-	// defer file.Close()
-
-	// buffer := bufio.NewWriter(file)
-	// _, err = buffer.Write(k8sObj)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to write JSON data to buffer: %w", err)
-	// }
-
-	// err = buffer.Flush()
-	// if err != nil {
-	// 	return fmt.Errorf("failed to flush writer: %w", err)
-	// }
-
 	return nil
 }
 

--- a/pkg/dump/writer/fs_writer_test.go
+++ b/pkg/dump/writer/fs_writer_test.go
@@ -1,0 +1,62 @@
+package writer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+func TestFSWriter_WriteFile(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	fileNameK8sObject := collector.EndpointPath
+	dummyNamespace := "namespace1"
+	dummyK8sObject := []*discoveryv1.EndpointSlice{
+		collector.FakeEndpoint("name1", "namespace1", []int32{int32(80)}),
+		collector.FakeEndpoint("name2", "namespace1", []int32{int32(443)}),
+	}
+
+	writer, err := NewFSWriter(ctx)
+	if err != nil {
+		t.Fatalf("failed to create file writer: %v", err)
+	}
+
+	vfsResourcePath := path.Join(dummyNamespace, fileNameK8sObject)
+
+	jsonData, err := json.Marshal(dummyK8sObject)
+	if err != nil {
+		t.Fatalf("failed to marshal Kubernetes object: %v", err)
+	}
+
+	err = writer.WriteFile(ctx, vfsResourcePath, jsonData)
+	if err != nil {
+		t.Fatalf("write %s: %v", reflect.TypeOf(dummyK8sObject), err)
+	}
+
+	file, err := writer.vfs.Open(vfsResourcePath)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	defer file.Close()
+	readK8sObject, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+
+	var processedDummyK8sObject []*discoveryv1.EndpointSlice
+	err = json.Unmarshal(readK8sObject, &processedDummyK8sObject)
+	if err != nil {
+		t.Fatalf("failed to unmarshal Kubernetes object: %v", err)
+	}
+
+	if !reflect.DeepEqual(processedDummyK8sObject, dummyK8sObject) {
+		t.Fatalf("expected %v, got %v", processedDummyK8sObject, readK8sObject)
+	}
+}

--- a/pkg/dump/writer/fs_writer_test.go
+++ b/pkg/dump/writer/fs_writer_test.go
@@ -59,4 +59,13 @@ func TestFSWriter_WriteFile(t *testing.T) {
 	if !reflect.DeepEqual(processedDummyK8sObject, dummyK8sObject) {
 		t.Fatalf("expected %v, got %v", processedDummyK8sObject, readK8sObject)
 	}
+
+	err = writer.Flush(ctx)
+	if err != nil {
+		t.Fatalf("failed to flush: %v", err)
+	}
+	err = writer.Close(ctx)
+	if err != nil {
+		t.Fatalf("failed to close: %v", err)
+	}
 }

--- a/pkg/dump/writer/mockwriter/writer.go
+++ b/pkg/dump/writer/mockwriter/writer.go
@@ -105,50 +105,6 @@ func (_c *DumperWriter_Flush_Call) RunAndReturn(run func(context.Context) error)
 	return _c
 }
 
-// Initialize provides a mock function with given fields: _a0, _a1, _a2
-func (_m *DumperWriter) Initialize(_a0 context.Context, _a1 string, _a2 string) error {
-	ret := _m.Called(_a0, _a1, _a2)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(_a0, _a1, _a2)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DumperWriter_Initialize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Initialize'
-type DumperWriter_Initialize_Call struct {
-	*mock.Call
-}
-
-// Initialize is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 string
-//   - _a2 string
-func (_e *DumperWriter_Expecter) Initialize(_a0 interface{}, _a1 interface{}, _a2 interface{}) *DumperWriter_Initialize_Call {
-	return &DumperWriter_Initialize_Call{Call: _e.mock.On("Initialize", _a0, _a1, _a2)}
-}
-
-func (_c *DumperWriter_Initialize_Call) Run(run func(_a0 context.Context, _a1 string, _a2 string)) *DumperWriter_Initialize_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *DumperWriter_Initialize_Call) Return(_a0 error) *DumperWriter_Initialize_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *DumperWriter_Initialize_Call) RunAndReturn(run func(context.Context, string, string) error) *DumperWriter_Initialize_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // OutputPath provides a mock function with given fields:
 func (_m *DumperWriter) OutputPath() string {
 	ret := _m.Called()
@@ -232,11 +188,11 @@ func (_c *DumperWriter_WorkerNumber_Call) RunAndReturn(run func() int) *DumperWr
 }
 
 // Write provides a mock function with given fields: _a0, _a1, _a2
-func (_m *DumperWriter) Write(_a0 context.Context, _a1 []byte, _a2 string) error {
+func (_m *DumperWriter) Write(_a0 context.Context, _a1 interface{}, _a2 string) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, []byte, string) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string) error); ok {
 		r0 = rf(_a0, _a1, _a2)
 	} else {
 		r0 = ret.Error(0)
@@ -252,15 +208,15 @@ type DumperWriter_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 []byte
+//   - _a1 interface{}
 //   - _a2 string
 func (_e *DumperWriter_Expecter) Write(_a0 interface{}, _a1 interface{}, _a2 interface{}) *DumperWriter_Write_Call {
 	return &DumperWriter_Write_Call{Call: _e.mock.On("Write", _a0, _a1, _a2)}
 }
 
-func (_c *DumperWriter_Write_Call) Run(run func(_a0 context.Context, _a1 []byte, _a2 string)) *DumperWriter_Write_Call {
+func (_c *DumperWriter_Write_Call) Run(run func(_a0 context.Context, _a1 interface{}, _a2 string)) *DumperWriter_Write_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]byte), args[2].(string))
+		run(args[0].(context.Context), args[1].(interface{}), args[2].(string))
 	})
 	return _c
 }
@@ -270,7 +226,7 @@ func (_c *DumperWriter_Write_Call) Return(_a0 error) *DumperWriter_Write_Call {
 	return _c
 }
 
-func (_c *DumperWriter_Write_Call) RunAndReturn(run func(context.Context, []byte, string) error) *DumperWriter_Write_Call {
+func (_c *DumperWriter_Write_Call) RunAndReturn(run func(context.Context, interface{}, string) error) *DumperWriter_Write_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/dump/writer/mockwriter/writer.go
+++ b/pkg/dump/writer/mockwriter/writer.go
@@ -188,11 +188,11 @@ func (_c *DumperWriter_WorkerNumber_Call) RunAndReturn(run func() int) *DumperWr
 }
 
 // Write provides a mock function with given fields: _a0, _a1, _a2
-func (_m *DumperWriter) Write(_a0 context.Context, _a1 interface{}, _a2 string) error {
+func (_m *DumperWriter) Write(_a0 context.Context, _a1 []byte, _a2 string) error {
 	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, interface{}, string) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, string) error); ok {
 		r0 = rf(_a0, _a1, _a2)
 	} else {
 		r0 = ret.Error(0)
@@ -208,15 +208,15 @@ type DumperWriter_Write_Call struct {
 
 // Write is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 interface{}
+//   - _a1 []byte
 //   - _a2 string
 func (_e *DumperWriter_Expecter) Write(_a0 interface{}, _a1 interface{}, _a2 interface{}) *DumperWriter_Write_Call {
 	return &DumperWriter_Write_Call{Call: _e.mock.On("Write", _a0, _a1, _a2)}
 }
 
-func (_c *DumperWriter_Write_Call) Run(run func(_a0 context.Context, _a1 interface{}, _a2 string)) *DumperWriter_Write_Call {
+func (_c *DumperWriter_Write_Call) Run(run func(_a0 context.Context, _a1 []byte, _a2 string)) *DumperWriter_Write_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(interface{}), args[2].(string))
+		run(args[0].(context.Context), args[1].([]byte), args[2].(string))
 	})
 	return _c
 }
@@ -226,7 +226,7 @@ func (_c *DumperWriter_Write_Call) Return(_a0 error) *DumperWriter_Write_Call {
 	return _c
 }
 
-func (_c *DumperWriter_Write_Call) RunAndReturn(run func(context.Context, interface{}, string) error) *DumperWriter_Write_Call {
+func (_c *DumperWriter_Write_Call) RunAndReturn(run func(context.Context, []byte, string) error) *DumperWriter_Write_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/dump/writer/tar_writer.go
+++ b/pkg/dump/writer/tar_writer.go
@@ -89,7 +89,6 @@ func (t *TarWriter) Write(ctx context.Context, k8sObj []byte, filePath string) e
 	defer t.mu.Unlock()
 
 	// Writing file to Afero memfs
-	fmt.Printf("filePath: %s\n", filePath)
 	err := t.fsWriter.WriteFile(ctx, filePath, k8sObj)
 	if err != nil {
 		return fmt.Errorf("write file %s: %w", filePath, err)

--- a/pkg/dump/writer/tar_writer_test.go
+++ b/pkg/dump/writer/tar_writer_test.go
@@ -1,0 +1,126 @@
+package writer
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/config"
+	"github.com/DataDog/KubeHound/pkg/ingestor/puller"
+	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+func TestTarWriter_Write(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tmpTarFileDir, err := os.MkdirTemp("/tmp/", "kh-unit-tests-*")
+	if err != nil {
+		log.I.Fatalf(err.Error())
+	}
+
+	tmpTarExtractDir, err := os.MkdirTemp("/tmp/", "kh-unit-tests-*")
+	if err != nil {
+		log.I.Fatalf(err.Error())
+	}
+
+	// Constructing a buffer of Endpoints objects in different namespaces/files
+	tarBundle := make(map[string]any)
+
+	fileNameK8sObject := collector.EndpointPath
+	dummyNamespace1 := "namespace1"
+	dummyK8sObject1 := []*discoveryv1.EndpointSlice{
+		collector.FakeEndpoint("name1", "namespace1", []int32{int32(80)}),
+		collector.FakeEndpoint("name2", "namespace1", []int32{int32(443)}),
+	}
+	vfsResourcePath1 := path.Join(dummyNamespace1, fileNameK8sObject)
+	tarBundle[vfsResourcePath1] = dummyK8sObject1
+
+	dummyNamespace2 := "namespace2"
+	dummyK8sObject2 := []*discoveryv1.EndpointSlice{
+		collector.FakeEndpoint("name1", "namespace2", []int32{int32(80)}),
+		collector.FakeEndpoint("name2", "namespace2", []int32{int32(443)}),
+	}
+	vfsResourcePath2 := path.Join(dummyNamespace2, fileNameK8sObject)
+	tarBundle[vfsResourcePath2] = dummyK8sObject2
+
+	writer, err := NewTarWriter(ctx, tmpTarFileDir, fileNameK8sObject)
+	if err != nil {
+		t.Fatalf("failed to create file writer: %v", err)
+	}
+
+	for vfsResourcePath, dummyK8sObject := range tarBundle {
+		jsonData, err := json.Marshal(dummyK8sObject)
+		if err != nil {
+			t.Fatalf("failed to marshal Kubernetes object: %v", err)
+		}
+		err = writer.Write(ctx, jsonData, vfsResourcePath)
+		if err != nil {
+			t.Fatalf("write %s: %v", reflect.TypeOf(dummyK8sObject), err)
+		}
+	}
+
+	writer.Flush(ctx)
+	writer.Close(ctx)
+
+	err = puller.ExtractTarGz(writer.OutputPath(), tmpTarExtractDir, config.DefaultMaxArchiveSize)
+	if err != nil {
+		t.Fatalf("failed to extract tar.gz: %v", err)
+	}
+
+	countFileSuccess := 0
+	err = filepath.Walk(tmpTarExtractDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Fatalf("failed to walk path: %v", err)
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("failed reading file: %v", err)
+		}
+		defer file.Close()
+		readK8sObject, err := io.ReadAll(file)
+		if err != nil {
+			t.Fatalf("failed reading file: %v", err)
+		}
+
+		var processedDummyK8sObject []*discoveryv1.EndpointSlice
+		err = json.Unmarshal(readK8sObject, &processedDummyK8sObject)
+		if err != nil {
+			t.Fatalf("failed to unmarshal Kubernetes object: %v", err)
+		}
+
+		// reformating the relative path from the virtual filesystem
+		vfsResourcePath := strings.ReplaceAll(tmpTarExtractDir, path, "")
+		if reflect.DeepEqual(processedDummyK8sObject, tarBundle[vfsResourcePath]) {
+			t.Fatalf("expected %v, got %v", processedDummyK8sObject, readK8sObject)
+		}
+		countFileSuccess++
+
+		err = os.Remove(file.Name())
+		if err != nil {
+			t.Fatalf("failed to remove file: %v", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk path: %v", err)
+	}
+
+	if countFileSuccess != len(tarBundle) {
+		t.Fatalf("expected %d, got %d", len(tarBundle), countFileSuccess)
+	}
+
+}

--- a/pkg/dump/writer/writer.go
+++ b/pkg/dump/writer/writer.go
@@ -2,14 +2,12 @@ package writer
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
 )
 
 const (
-	WriterDirChmod = 0700
+	WriterDirMod = 0700
 )
 
 // The DumperWriter handle multiple types of writer (file, tar, ...)
@@ -18,7 +16,7 @@ const (
 //
 //go:generate mockery --name DumperWriter --output mockwriter --case underscore --filename writer.go --with-expecter
 type DumperWriter interface {
-	Write(context.Context, any, string) error
+	Write(context.Context, []byte, string) error
 	Flush(context.Context) error
 	Close(context.Context) error
 
@@ -38,13 +36,4 @@ func DumperWriterFactory(ctx context.Context, compression bool, directoryPath st
 	}
 
 	return NewFileWriter(ctx, directoryPath, resultName)
-}
-
-func marshalK8sObj(obj interface{}) ([]byte, error) {
-	jsonData, err := json.Marshal(obj)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal Kubernetes object: %w", err)
-	}
-
-	return jsonData, nil
 }

--- a/pkg/dump/writer/writer.go
+++ b/pkg/dump/writer/writer.go
@@ -2,6 +2,8 @@ package writer
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
 )
@@ -16,7 +18,7 @@ const (
 //
 //go:generate mockery --name DumperWriter --output mockwriter --case underscore --filename writer.go --with-expecter
 type DumperWriter interface {
-	Write(context.Context, []byte, string) error
+	Write(context.Context, any, string) error
 	Flush(context.Context) error
 	Close(context.Context) error
 
@@ -36,4 +38,13 @@ func DumperWriterFactory(ctx context.Context, compression bool, directoryPath st
 	}
 
 	return NewFileWriter(ctx, directoryPath, resultName)
+}
+
+func marshalK8sObj(obj interface{}) ([]byte, error) {
+	jsonData, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Kubernetes object: %w", err)
+	}
+
+	return jsonData, nil
 }


### PR DESCRIPTION
Refactor the writer to be compatible with the collector. The collector needs to have an abstract layer k8sTypeList, so it means we can no longer dump raw files directly, we need to consolidate all the entries for each files first.

For the file writer, we build a buffer for each file, then write it to the filesystem [buffer -> raw fs.FS]
For the tar writer, there is one more step, instead of writing directly to the tar, we write the file to a "memory fs" using afero lib. [buffer --> aerofs FS --> tar fs.FS]

This allows to support for both writer, partial multi-threading. 