### PR TITLE
[Dumper] Rework of the object ingestion

### DIFF
--- a/pkg/dump/pipeline/cluster_role_binding_ingest.go
+++ b/pkg/dump/pipeline/cluster_role_binding_ingest.go
@@ -1,0 +1,37 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/DataDog/KubeHound/pkg/kubehound/ingestor/preflight"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type ClusterRoleBindingIngestor struct {
+	buffer map[string]*rbacv1.ClusterRoleBindingList
+	writer writer.DumperWriter
+}
+
+func NewClusterRoleBindingIngestor(ctx context.Context, dumpWriter writer.DumperWriter) *ClusterRoleBindingIngestor {
+	return &ClusterRoleBindingIngestor{
+		buffer: make(map[string]*rbacv1.ClusterRoleBindingList),
+		writer: dumpWriter,
+	}
+}
+
+func (d *ClusterRoleBindingIngestor) IngestClusterRoleBinding(ctx context.Context, clusterRoleBinding types.ClusterRoleBindingType) error {
+	if ok, err := preflight.CheckClusterRoleBinding(clusterRoleBinding); !ok {
+		return err
+	}
+
+	return bufferObject[rbacv1.ClusterRoleBindingList, types.ClusterRoleBindingType](ctx, collector.ClusterRoleBindingsPath, d.buffer, clusterRoleBinding)
+}
+
+// Complete() is invoked by the collector when all k8s assets have been streamed.
+// The function flushes all writers and waits for completion.
+func (d *ClusterRoleBindingIngestor) Complete(ctx context.Context) error {
+	return dumpObj[*rbacv1.ClusterRoleBindingList](ctx, d.buffer, d.writer)
+}

--- a/pkg/dump/pipeline/cluster_role_binding_ingest_test.go
+++ b/pkg/dump/pipeline/cluster_role_binding_ingest_test.go
@@ -1,0 +1,89 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	mockwriter "github.com/DataDog/KubeHound/pkg/dump/writer/mockwriter"
+	"github.com/stretchr/testify/mock"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestDumpIngestor_IngestClusterRoleBinding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// no ingestion
+	noIngest := func(t *testing.T, _ []*rbacv1.ClusterRoleBinding) *ClusterRoleBindingIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewClusterRoleBindingIngestor(ctx, mDumpWriter)
+
+		return ingestor
+	}
+
+	// ingesting n entries
+	nIngest := func(t *testing.T, clusterRole []*rbacv1.ClusterRoleBinding) *ClusterRoleBindingIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewClusterRoleBindingIngestor(ctx, mDumpWriter)
+
+		buffer := &rbacv1.ClusterRoleBindingList{}
+
+		for _, clusterRole := range clusterRole {
+			buffer.Items = append(buffer.Items, *clusterRole)
+		}
+		mDumpWriter.EXPECT().Write(mock.Anything, buffer, collector.ClusterRolesPath).Return(nil).Once()
+
+		return ingestor
+	}
+
+	type args struct {
+		clusterRoleBinding []*rbacv1.ClusterRoleBinding
+	}
+	tests := []struct {
+		name           string
+		dumperIngestor *ClusterRoleIngestor
+		testfct        func(t *testing.T, clusterRole []*rbacv1.ClusterRoleBinding) *ClusterRoleBindingIngestor
+		args           args
+		wantErr        bool
+	}{
+		{
+			name:    "no entry",
+			testfct: noIngest,
+			args: args{
+				clusterRoleBinding: []*rbacv1.ClusterRoleBinding{
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entries found",
+			testfct: nIngest,
+			args: args{
+				clusterRoleBinding: []*rbacv1.ClusterRoleBinding{
+					collector.FakeClusterRoleBinding("name1"),
+					collector.FakeClusterRoleBinding("name2"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ingestor := tt.testfct(t, tt.args.clusterRoleBinding)
+			for _, clusterRoleBinding := range tt.args.clusterRoleBinding {
+				if err := ingestor.IngestClusterRoleBinding(ctx, clusterRoleBinding); (err != nil) != tt.wantErr {
+					t.Errorf("Dumper.IngestNode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if err := ingestor.Complete(ctx); err != nil {
+				t.Errorf("Dumper.IngestNode() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/dump/pipeline/cluster_role_ingest.go
+++ b/pkg/dump/pipeline/cluster_role_ingest.go
@@ -1,0 +1,39 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/DataDog/KubeHound/pkg/kubehound/ingestor/preflight"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type ClusterRoleIngestor struct {
+	buffer map[string]*rbacv1.ClusterRoleList
+	writer writer.DumperWriter
+}
+
+func NewClusterRoleIngestor(ctx context.Context, dumpWriter writer.DumperWriter) *ClusterRoleIngestor {
+	return &ClusterRoleIngestor{
+		buffer: make(map[string]*rbacv1.ClusterRoleList),
+		writer: dumpWriter,
+	}
+}
+
+func (d *ClusterRoleIngestor) IngestClusterRole(ctx context.Context, clusterRole types.ClusterRoleType) error {
+	if ok, err := preflight.CheckClusterRole(clusterRole); !ok {
+		return err
+	}
+
+	clusterRolePath := collector.ClusterRolesPath
+
+	return bufferObject[rbacv1.ClusterRoleList, types.ClusterRoleType](ctx, clusterRolePath, d.buffer, clusterRole)
+}
+
+// Complete() is invoked by the collector when all k8s assets have been streamed.
+// The function flushes all writers and waits for completion.
+func (d *ClusterRoleIngestor) Complete(ctx context.Context) error {
+	return dumpObj[*rbacv1.ClusterRoleList](ctx, d.buffer, d.writer)
+}

--- a/pkg/dump/pipeline/cluster_role_ingest_test.go
+++ b/pkg/dump/pipeline/cluster_role_ingest_test.go
@@ -1,0 +1,89 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	mockwriter "github.com/DataDog/KubeHound/pkg/dump/writer/mockwriter"
+	"github.com/stretchr/testify/mock"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestDumpIngestor_IngestClusterRole(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// no ingestion
+	noIngest := func(t *testing.T, _ []*rbacv1.ClusterRole) *ClusterRoleIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewClusterRoleIngestor(ctx, mDumpWriter)
+
+		return ingestor
+	}
+
+	// ingesting n entries
+	nIngest := func(t *testing.T, clusterRole []*rbacv1.ClusterRole) *ClusterRoleIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewClusterRoleIngestor(ctx, mDumpWriter)
+
+		buffer := &rbacv1.ClusterRoleList{}
+
+		for _, clusterRole := range clusterRole {
+			buffer.Items = append(buffer.Items, *clusterRole)
+		}
+		mDumpWriter.EXPECT().Write(mock.Anything, buffer, collector.ClusterRolesPath).Return(nil).Once()
+
+		return ingestor
+	}
+
+	type args struct {
+		clusterRoles []*rbacv1.ClusterRole
+	}
+	tests := []struct {
+		name     string
+		ingestor *ClusterRoleIngestor
+		testfct  func(t *testing.T, clusterRole []*rbacv1.ClusterRole) *ClusterRoleIngestor
+		args     args
+		wantErr  bool
+	}{
+		{
+			name:    "no entry",
+			testfct: noIngest,
+			args: args{
+				clusterRoles: []*rbacv1.ClusterRole{
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entries found",
+			testfct: nIngest,
+			args: args{
+				clusterRoles: []*rbacv1.ClusterRole{
+					collector.FakeClusterRole("name1"),
+					collector.FakeClusterRole("name2"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ingestor := tt.testfct(t, tt.args.clusterRoles)
+			for _, clusterRole := range tt.args.clusterRoles {
+				if err := ingestor.IngestClusterRole(ctx, clusterRole); (err != nil) != tt.wantErr {
+					t.Errorf("Dumper.IngestNode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if err := ingestor.Complete(ctx); err != nil {
+				t.Errorf("Dumper.IngestNode() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/dump/pipeline/endpoint_ingest.go
+++ b/pkg/dump/pipeline/endpoint_ingest.go
@@ -1,0 +1,44 @@
+package pipeline
+
+import (
+	"context"
+	"path"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/DataDog/KubeHound/pkg/kubehound/ingestor/preflight"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+type EndpointIngestor struct {
+	buffer map[string]*discoveryv1.EndpointSliceList
+	writer writer.DumperWriter
+}
+
+func ingestEndpointPath(endpoint types.EndpointType) string {
+	return path.Join(endpoint.Namespace, collector.EndpointPath)
+}
+
+func NewEndpointIngestor(ctx context.Context, dumpWriter writer.DumperWriter) *EndpointIngestor {
+	return &EndpointIngestor{
+		buffer: make(map[string]*discoveryv1.EndpointSliceList),
+		writer: dumpWriter,
+	}
+}
+
+func (d *EndpointIngestor) IngestEndpoint(ctx context.Context, endpoint types.EndpointType) error {
+	if ok, err := preflight.CheckEndpoint(endpoint); !ok {
+		return err
+	}
+
+	endpointPath := ingestEndpointPath(endpoint)
+
+	return bufferObject[discoveryv1.EndpointSliceList, types.EndpointType](ctx, endpointPath, d.buffer, endpoint)
+}
+
+// Complete() is invoked by the collector when all k8s assets have been streamed.
+// The function flushes all writers and waits for completion.
+func (d *EndpointIngestor) Complete(ctx context.Context) error {
+	return dumpObj[*discoveryv1.EndpointSliceList](ctx, d.buffer, d.writer)
+}

--- a/pkg/dump/pipeline/endpoint_ingest_test.go
+++ b/pkg/dump/pipeline/endpoint_ingest_test.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	mockwriter "github.com/DataDog/KubeHound/pkg/dump/writer/mockwriter"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	discoveryv1 "k8s.io/api/discovery/v1"
+)
+
+func TestDumpIngestor_IngestEndpoint(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// no ingestion
+	noIngest := func(t *testing.T, _ []*discoveryv1.EndpointSlice) *EndpointIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewEndpointIngestor(ctx, mDumpWriter)
+
+		return ingestor
+	}
+
+	// ingesting n entries
+	nIngest := func(t *testing.T, endpoints []*discoveryv1.EndpointSlice) *EndpointIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewEndpointIngestor(ctx, mDumpWriter)
+
+		buffer := make(map[string]*discoveryv1.EndpointSliceList)
+		for _, endpoint := range endpoints {
+			err := bufferObject[discoveryv1.EndpointSliceList, types.EndpointType](ctx, ingestEndpointPath(endpoint), buffer, endpoint)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		for path, endpoint := range buffer {
+			mDumpWriter.EXPECT().Write(ctx, endpoint, path).Return(nil).Once()
+		}
+
+		return ingestor
+	}
+
+	type args struct {
+		endpoints []*discoveryv1.EndpointSlice
+	}
+	tests := []struct {
+		name     string
+		ingestor *EndpointIngestor
+		testfct  func(t *testing.T, clusterRole []*discoveryv1.EndpointSlice) *EndpointIngestor
+		args     args
+		wantErr  bool
+	}{
+		{
+			name:    "no entry",
+			testfct: noIngest,
+			args: args{
+				endpoints: []*discoveryv1.EndpointSlice{
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entries found",
+			testfct: nIngest,
+			args: args{
+				endpoints: []*discoveryv1.EndpointSlice{
+					collector.FakeEndpoint("name1", "namespace1", []int32{int32(80)}),
+					collector.FakeEndpoint("name2", "namespace2", []int32{int32(443)}),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ingestor := tt.testfct(t, tt.args.endpoints)
+			for _, endpoint := range tt.args.endpoints {
+				if err := ingestor.IngestEndpoint(ctx, endpoint); (err != nil) != tt.wantErr {
+					t.Errorf("Dumper.IngestNode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if err := ingestor.Complete(ctx); err != nil {
+				t.Errorf("Dumper.IngestNode() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/dump/pipeline/node_ingest.go
+++ b/pkg/dump/pipeline/node_ingest.go
@@ -1,0 +1,38 @@
+package pipeline
+
+import (
+	"context"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/DataDog/KubeHound/pkg/kubehound/ingestor/preflight"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type NodeIngestor struct {
+	buffer map[string]*corev1.NodeList
+	writer writer.DumperWriter
+}
+
+func NewNodeIngestor(ctx context.Context, dumpWriter writer.DumperWriter) *NodeIngestor {
+	return &NodeIngestor{
+		buffer: make(map[string]*corev1.NodeList),
+		writer: dumpWriter,
+	}
+}
+
+func (d *NodeIngestor) IngestNode(ctx context.Context, node types.NodeType) error {
+	if ok, err := preflight.CheckNode(node); !ok {
+		return err
+	}
+
+	return bufferObject[corev1.NodeList, types.NodeType](ctx, collector.NodePath, d.buffer, node)
+}
+
+// Complete() is invoked by the collector when all k8s assets have been streamed.
+// The function flushes all writers and waits for completion.
+func (d *NodeIngestor) Complete(ctx context.Context) error {
+	return dumpObj[*corev1.NodeList](ctx, d.buffer, d.writer)
+}

--- a/pkg/dump/pipeline/node_ingest_test.go
+++ b/pkg/dump/pipeline/node_ingest_test.go
@@ -1,0 +1,90 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	mockwriter "github.com/DataDog/KubeHound/pkg/dump/writer/mockwriter"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDumpIngestor_IngestNode(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// no ingestion
+	noIngest := func(t *testing.T, _ []types.NodeType) *NodeIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewNodeIngestor(ctx, mDumpWriter)
+
+		return ingestor
+	}
+
+	// ingesting n entries
+	nIngest := func(t *testing.T, nodes []types.NodeType) *NodeIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewNodeIngestor(ctx, mDumpWriter)
+
+		buffer := &corev1.NodeList{}
+
+		for _, node := range nodes {
+			buffer.Items = append(buffer.Items, *node)
+		}
+		mDumpWriter.EXPECT().Write(mock.Anything, buffer, collector.NodePath).Return(nil).Once()
+
+		return ingestor
+	}
+
+	type args struct {
+		nodes []types.NodeType
+	}
+	tests := []struct {
+		name           string
+		dumperIngestor *ClusterRoleIngestor
+		testfct        func(t *testing.T, clusterRole []types.NodeType) *NodeIngestor
+		args           args
+		wantErr        bool
+	}{
+		{
+			name:    "no entry",
+			testfct: noIngest,
+			args: args{
+				nodes: []types.NodeType{
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entries found",
+			testfct: nIngest,
+			args: args{
+				nodes: []types.NodeType{
+					collector.FakeNode("name1", "provider1"),
+					collector.FakeNode("name2", "provider2"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ingestor := tt.testfct(t, tt.args.nodes)
+			for _, node := range tt.args.nodes {
+				if err := ingestor.IngestNode(ctx, node); (err != nil) != tt.wantErr {
+					t.Errorf("Dumper.IngestNode() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if err := ingestor.Complete(ctx); err != nil {
+				t.Errorf("Dumper.IngestNode() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/dump/pipeline/object_ingest.go
+++ b/pkg/dump/pipeline/object_ingest.go
@@ -1,0 +1,95 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func addK8sObjToTypeList(_ context.Context, object any, objectList any) error {
+	switch o := objectList.(type) {
+	case *rbacv1.ClusterRoleList:
+		val, ok := object.(types.ClusterRoleType)
+		if !ok {
+			return fmt.Errorf("failed to cast object to ClusterRoleType: %s", reflect.TypeOf(object).String())
+		}
+		o.Items = append(o.Items, *val)
+	case *rbacv1.ClusterRoleBindingList:
+		val, ok := object.(types.ClusterRoleBindingType)
+		if !ok {
+			return fmt.Errorf("failed to cast object to ClusterRoleBindingType: %s", reflect.TypeOf(object).String())
+		}
+		o.Items = append(o.Items, *val)
+	case *rbacv1.RoleList:
+		val, ok := object.(types.RoleType)
+		if !ok {
+			return fmt.Errorf("failed to cast object to RoleType: %s", reflect.TypeOf(object).String())
+		}
+		o.Items = append(o.Items, *val)
+	case *rbacv1.RoleBindingList:
+		val, ok := object.(types.RoleBindingType)
+		if !ok {
+			return fmt.Errorf("failed to cast object to RoleBindingType: %s", reflect.TypeOf(object).String())
+
+		}
+		o.Items = append(o.Items, *val)
+	case *discoveryv1.EndpointSliceList:
+		val, ok := object.(types.EndpointType)
+		if !ok {
+			return fmt.Errorf("failed to cast object to EndpointType: %s", reflect.TypeOf(object).String())
+		}
+		o.Items = append(o.Items, *val)
+	case *corev1.PodList:
+		val, ok := object.(types.PodType)
+		if !ok {
+			return fmt.Errorf("failed to cast object to PodType: %s", reflect.TypeOf(object).String())
+		}
+		o.Items = append(o.Items, *val)
+	case *corev1.NodeList:
+		val, ok := object.(types.NodeType)
+		if !ok {
+			return fmt.Errorf("failed to cast object to NodeType: %s", reflect.TypeOf(object).String())
+		}
+		o.Items = append(o.Items, *val)
+	default:
+		return fmt.Errorf("unknown object type to cast: %s", reflect.TypeOf(object).String())
+	}
+
+	return nil
+
+}
+
+func bufferObject[T any, V any](ctx context.Context, filePath string, buffer map[string]*T, node V) error {
+	_, ok := buffer[filePath]
+	if !ok {
+		var newBuffer T
+		buffer[filePath] = &newBuffer
+	}
+
+	return addK8sObjToTypeList(ctx, node, buffer[filePath])
+}
+
+func dumpObj[T any](ctx context.Context, buffer map[string]T, writer writer.DumperWriter) error {
+	for path, buf := range buffer {
+		jsonData, err := json.Marshal(buf)
+		if err != nil {
+			return fmt.Errorf("failed to marshal Kubernetes object: %w", err)
+		}
+
+		err = writer.Write(ctx, jsonData, path)
+		if err != nil {
+			return fmt.Errorf("write %s: %w", reflect.TypeOf(buf), err)
+		}
+		delete(buffer, path)
+	}
+
+	return nil
+}

--- a/pkg/dump/pipeline/pod_ingest.go
+++ b/pkg/dump/pipeline/pod_ingest.go
@@ -1,0 +1,45 @@
+package pipeline
+
+import (
+	"context"
+	"path"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/DataDog/KubeHound/pkg/kubehound/ingestor/preflight"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ingestPodPath(pod types.PodType) string {
+	return path.Join(pod.Namespace, collector.PodPath)
+}
+
+type PodIngestor struct {
+	buffer map[string]*corev1.PodList
+	writer writer.DumperWriter
+}
+
+func NewPodIngestor(ctx context.Context, dumpWriter writer.DumperWriter) *PodIngestor {
+	return &PodIngestor{
+		buffer: make(map[string]*corev1.PodList),
+		writer: dumpWriter,
+	}
+}
+
+func (d *PodIngestor) IngestPod(ctx context.Context, pod types.PodType) error {
+	if ok, err := preflight.CheckPod(pod); !ok {
+		return err
+	}
+
+	podPath := ingestPodPath(pod)
+
+	return bufferObject[corev1.PodList, types.PodType](ctx, podPath, d.buffer, pod)
+}
+
+// Complete() is invoked by the collector when all k8s assets have been streamed.
+// The function flushes all writers and waits for completion.
+func (d *PodIngestor) Complete(ctx context.Context) error {
+	return dumpObj[*corev1.PodList](ctx, d.buffer, d.writer)
+}

--- a/pkg/dump/pipeline/pod_ingest_test.go
+++ b/pkg/dump/pipeline/pod_ingest_test.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	mockwriter "github.com/DataDog/KubeHound/pkg/dump/writer/mockwriter"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDumpIngestor_IngestPod(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// no ingestion
+	noIngest := func(t *testing.T, _ []types.PodType) *PodIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewPodIngestor(ctx, mDumpWriter)
+
+		return ingestor
+	}
+
+	// ingesting n entries
+	nIngest := func(t *testing.T, pods []types.PodType) *PodIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewPodIngestor(ctx, mDumpWriter)
+
+		buffer := make(map[string]*corev1.PodList)
+		for _, pod := range pods {
+			err := bufferObject[corev1.PodList, types.PodType](ctx, ingestPodPath(pod), buffer, pod)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		for path, endpoint := range buffer {
+			mDumpWriter.EXPECT().Write(ctx, endpoint, path).Return(nil).Once()
+		}
+
+		return ingestor
+	}
+
+	type args struct {
+		pods []types.PodType
+	}
+	tests := []struct {
+		name     string
+		ingestor *PodIngestor
+		testfct  func(t *testing.T, clusterRole []types.PodType) *PodIngestor
+		args     args
+		wantErr  bool
+	}{
+		{
+			name:    "no entry",
+			testfct: noIngest,
+			args: args{
+				pods: []types.PodType{
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entries found",
+			testfct: nIngest,
+			args: args{
+				pods: []types.PodType{
+					collector.FakePod("name1", "image1", "Running"),
+					collector.FakePod("name2", "image2", "Running"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ingestor := tt.testfct(t, tt.args.pods)
+			for _, pod := range tt.args.pods {
+				if err := ingestor.IngestPod(ctx, pod); (err != nil) != tt.wantErr {
+					t.Errorf("ingestor.IngestPod() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if err := ingestor.Complete(ctx); err != nil {
+				t.Errorf("ingestor.Complete() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/dump/pipeline/role_binding_ingest.go
+++ b/pkg/dump/pipeline/role_binding_ingest.go
@@ -1,0 +1,44 @@
+package pipeline
+
+import (
+	"context"
+	"path"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/DataDog/KubeHound/pkg/kubehound/ingestor/preflight"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type RoleBindingIngestor struct {
+	buffer map[string]*rbacv1.RoleBindingList
+	writer writer.DumperWriter
+}
+
+func ingestRoleBindingPath(roleBinding types.RoleBindingType) string {
+	return path.Join(roleBinding.Namespace, collector.RoleBindingsPath)
+}
+
+func NewRoleBindingIngestor(ctx context.Context, dumpWriter writer.DumperWriter) *RoleBindingIngestor {
+	return &RoleBindingIngestor{
+		buffer: make(map[string]*rbacv1.RoleBindingList),
+		writer: dumpWriter,
+	}
+}
+
+func (d *RoleBindingIngestor) IngestRoleBinding(ctx context.Context, roleBinding types.RoleBindingType) error {
+	if ok, err := preflight.CheckRoleBinding(roleBinding); !ok {
+		return err
+	}
+
+	roleBindingPath := ingestRoleBindingPath(roleBinding)
+
+	return bufferObject[rbacv1.RoleBindingList, types.RoleBindingType](ctx, roleBindingPath, d.buffer, roleBinding)
+}
+
+// Complete() is invoked by the collector when all k8s assets have been streamed.
+// The function flushes all writers and waits for completion.
+func (d *RoleBindingIngestor) Complete(ctx context.Context) error {
+	return dumpObj[*rbacv1.RoleBindingList](ctx, d.buffer, d.writer)
+}

--- a/pkg/dump/pipeline/role_binding_ingest_test.go
+++ b/pkg/dump/pipeline/role_binding_ingest_test.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	mockwriter "github.com/DataDog/KubeHound/pkg/dump/writer/mockwriter"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestDumpIngestor_IngestRoleBinding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// no ingestion
+	noIngest := func(t *testing.T, _ []types.RoleBindingType) *RoleBindingIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewRoleBindingIngestor(ctx, mDumpWriter)
+
+		return ingestor
+	}
+
+	// ingesting n entries
+	nIngest := func(t *testing.T, roleBindings []types.RoleBindingType) *RoleBindingIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewRoleBindingIngestor(ctx, mDumpWriter)
+
+		buffer := make(map[string]*rbacv1.RoleBindingList)
+		for _, roleBinding := range roleBindings {
+			err := bufferObject[rbacv1.RoleBindingList, types.RoleBindingType](ctx, ingestRoleBindingPath(roleBinding), buffer, roleBinding)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		for path, endpoint := range buffer {
+			mDumpWriter.EXPECT().Write(ctx, endpoint, path).Return(nil).Once()
+		}
+
+		return ingestor
+	}
+
+	type args struct {
+		roleBindings []types.RoleBindingType
+	}
+	tests := []struct {
+		name     string
+		ingestor *RoleBindingIngestor
+		testfct  func(t *testing.T, clusterRole []types.RoleBindingType) *RoleBindingIngestor
+		args     args
+		wantErr  bool
+	}{
+		{
+			name:    "no entry",
+			testfct: noIngest,
+			args: args{
+				roleBindings: []types.RoleBindingType{
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entries found",
+			testfct: nIngest,
+			args: args{
+				roleBindings: []types.RoleBindingType{
+					collector.FakeRoleBinding("namespace1", "name1"),
+					collector.FakeRoleBinding("namespace2", "name2"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ingestor := tt.testfct(t, tt.args.roleBindings)
+			for _, roleBinding := range tt.args.roleBindings {
+				if err := ingestor.IngestRoleBinding(ctx, roleBinding); (err != nil) != tt.wantErr {
+					t.Errorf("ingestor.IngestRoleBinding() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if err := ingestor.Complete(ctx); err != nil {
+				t.Errorf("ingestor.Complete() error = %v", err)
+			}
+		})
+	}
+}

--- a/pkg/dump/pipeline/role_ingest.go
+++ b/pkg/dump/pipeline/role_ingest.go
@@ -1,0 +1,44 @@
+package pipeline
+
+import (
+	"context"
+	"path"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	"github.com/DataDog/KubeHound/pkg/dump/writer"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	"github.com/DataDog/KubeHound/pkg/kubehound/ingestor/preflight"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type RoleIngestor struct {
+	buffer map[string]*rbacv1.RoleList
+	writer writer.DumperWriter
+}
+
+func ingestRolePath(roleBinding types.RoleType) string {
+	return path.Join(roleBinding.Namespace, collector.RolesPath)
+}
+
+func NewRoleIngestor(ctx context.Context, dumpWriter writer.DumperWriter) *RoleIngestor {
+	return &RoleIngestor{
+		buffer: make(map[string]*rbacv1.RoleList),
+		writer: dumpWriter,
+	}
+}
+
+func (d *RoleIngestor) IngestRole(ctx context.Context, role types.RoleType) error {
+	if ok, err := preflight.CheckRole(role); !ok {
+		return err
+	}
+
+	rolePath := ingestRolePath(role)
+
+	return bufferObject[rbacv1.RoleList, types.RoleType](ctx, rolePath, d.buffer, role)
+}
+
+// Complete() is invoked by the collector when all k8s assets have been streamed.
+// The function flushes all writers and waits for completion.
+func (d *RoleIngestor) Complete(ctx context.Context) error {
+	return dumpObj[*rbacv1.RoleList](ctx, d.buffer, d.writer)
+}

--- a/pkg/dump/pipeline/role_ingest_test.go
+++ b/pkg/dump/pipeline/role_ingest_test.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/KubeHound/pkg/collector"
+	mockwriter "github.com/DataDog/KubeHound/pkg/dump/writer/mockwriter"
+	"github.com/DataDog/KubeHound/pkg/globals/types"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestDumpIngestor_IngestRole(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// no ingestion
+	noIngest := func(t *testing.T, _ []types.RoleType) *RoleIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewRoleIngestor(ctx, mDumpWriter)
+
+		return ingestor
+	}
+
+	// ingesting n entries
+	nIngest := func(t *testing.T, roles []types.RoleType) *RoleIngestor {
+		t.Helper()
+		mDumpWriter := mockwriter.NewDumperWriter(t)
+		ingestor := NewRoleIngestor(ctx, mDumpWriter)
+
+		buffer := make(map[string]*rbacv1.RoleList)
+		for _, role := range roles {
+			err := bufferObject[rbacv1.RoleList, types.RoleType](ctx, ingestRolePath(role), buffer, role)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		for path, endpoint := range buffer {
+			mDumpWriter.EXPECT().Write(ctx, endpoint, path).Return(nil).Once()
+		}
+
+		return ingestor
+	}
+
+	type args struct {
+		roles []types.RoleType
+	}
+	tests := []struct {
+		name     string
+		ingestor *RoleIngestor
+		testfct  func(t *testing.T, clusterRole []types.RoleType) *RoleIngestor
+		args     args
+		wantErr  bool
+	}{
+		{
+			name:    "no entry",
+			testfct: noIngest,
+			args: args{
+				roles: []types.RoleType{
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "entries found",
+			testfct: nIngest,
+			args: args{
+				roles: []types.RoleType{
+					collector.FakeRole("namespace1", "name1"),
+					collector.FakeRole("namespace2", "name2"),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ingestor := tt.testfct(t, tt.args.roles)
+			for _, role := range tt.args.roles {
+				if err := ingestor.IngestRole(ctx, role); (err != nil) != tt.wantErr {
+					t.Errorf("ingestor.IngestRole() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			}
+			if err := ingestor.Complete(ctx); err != nil {
+				t.Errorf("ingestor.Complete() error = %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Create an interface for each object type to add the ability to create an objectList for each k8s type. For instance all endpoint stack them into a discoveryv1.EndpointSliceList. This is needed by the collector. 
Effort were already made to be fully supported by the writers (tar and file one).