### PR TITLE
Use `mongosh` instead of `mongo`

### DIFF
--- a/deployments/kubehound/mongo/docker-healthcheck
+++ b/deployments/kubehound/mongo/docker-healthcheck
@@ -3,7 +3,7 @@ set -eo pipefail
 
 host="$(hostname --ip-address || echo '127.0.0.1')"
 
-if mongo --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
+if mongosh --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
 	exit 0
 fi
 


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets -->

Fix a secondary issue raised in #143.
Thanks @kovacs-levent for pointing it out and finding the origin of the issue

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links -->

Use `mongosh` instead of `mongo` in the healthcheck script. As pointed out, `mongo` has been [deprecated](https://www.mongodb.com/docs/manual/release-notes/6.0-compatibility/#legacy-mongo-shell-removed) for version > 6.0
