### PR TITLE
Support for TLS in kubehound collector

### DIFF
--- a/cmd/kubehound/grpc_client.go
+++ b/cmd/kubehound/grpc_client.go
@@ -19,7 +19,7 @@ var (
 			viper.BindPFlag(config.IngestorAPIEndpoint, cobraCmd.Flags().Lookup("khaas-server")) //nolint: errcheck
 			viper.BindPFlag(config.IngestorAPIInsecure, cobraCmd.Flags().Lookup("insecure"))     //nolint: errcheck
 
-			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), "", false, false)
+			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), "", false, true)
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Passing the Kubehound config from viper

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -76,7 +76,7 @@ func TestMustLoadConfig(t *testing.T) {
 				Ingestor: IngestorConfig{
 					API: IngestorAPIConfig{
 						Endpoint: "127.0.0.1:9000",
-						Insecure: true,
+						Insecure: false,
 					},
 					Blob: &BlobConfig{
 						Bucket: "",
@@ -142,7 +142,7 @@ func TestMustLoadConfig(t *testing.T) {
 				Ingestor: IngestorConfig{
 					API: IngestorAPIConfig{
 						Endpoint: "127.0.0.1:9000",
-						Insecure: true,
+						Insecure: false,
 					},
 					Blob: &BlobConfig{
 						Bucket: "",

--- a/pkg/config/ingestor.go
+++ b/pkg/config/ingestor.go
@@ -2,7 +2,7 @@ package config
 
 const (
 	DefaultIngestorAPIEndpoint = "127.0.0.1:9000"
-	DefaultIngestorAPIInsecure = true
+	DefaultIngestorAPIInsecure = false
 	DefaultBucketName          = "" // we want to let it empty because we can easily abort if it's not configured
 	DefaultTempDir             = "/tmp/kubehound"
 	DefaultArchiveName         = "archive.tar.gz"

--- a/pkg/kubehound/core/core_grpc_client.go
+++ b/pkg/kubehound/core/core_grpc_client.go
@@ -2,12 +2,14 @@ package core
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 
 	"github.com/DataDog/KubeHound/pkg/config"
 	pb "github.com/DataDog/KubeHound/pkg/ingestor/api/grpc/pb"
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -16,7 +18,11 @@ func CoreClientGRPCIngest(ingestorConfig config.IngestorConfig, clusteName strin
 	if ingestorConfig.API.Insecure {
 		dialOpt = grpc.WithTransportCredentials(insecure.NewCredentials())
 	} else {
-		return fmt.Errorf("secure connection is not supported")
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: false,
+			MinVersion:         tls.VersionTLS12,
+		}
+		dialOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
 	log.I.Infof("Launching ingestion on %s [%s:%s]", ingestorConfig.API.Endpoint, clusteName, runID)


### PR DESCRIPTION
Support for TLS in Kubehound collector, even if the kubehound ingestor does not currently support it, we can expose the GRPC endpoint after a TLS broker/proxy.

A fix also in the kubehound collector to use inline args.