### PR TITLE
Fix unit test

### DIFF
--- a/pkg/ingestor/api/api.go
+++ b/pkg/ingestor/api/api.go
@@ -68,7 +68,7 @@ func (g *IngestorAPI) Ingest(_ context.Context, clusterName string, runID string
 	var err error
 	defer func() { spanJob.Finish(tracer.WithError(err)) }()
 
-	alreadyIngested, err := g.isAlreadyIngestedDB(runCtx, clusterName, runID) //nolint: contextcheck
+	alreadyIngested, err := g.isAlreadyIngestedInDB(runCtx, clusterName, runID) //nolint: contextcheck
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (g *IngestorAPI) Ingest(_ context.Context, clusterName string, runID string
 	return nil
 }
 
-func (g *IngestorAPI) isAlreadyIngestedDB(ctx context.Context, clusterName string, runID string) (bool, error) {
+func (g *IngestorAPI) isAlreadyIngestedInDB(ctx context.Context, clusterName string, runID string) (bool, error) {
 	var resNum int64
 	var err error
 	for _, collection := range collections.GetCollections() {

--- a/pkg/ingestor/api/api.go
+++ b/pkg/ingestor/api/api.go
@@ -68,7 +68,7 @@ func (g *IngestorAPI) Ingest(_ context.Context, clusterName string, runID string
 	var err error
 	defer func() { spanJob.Finish(tracer.WithError(err)) }()
 
-	alreadyIngested, err := g.isAlreadyIngested(runCtx, clusterName, runID) //nolint: contextcheck
+	alreadyIngested, err := g.isAlreadyIngestedDB(runCtx, clusterName, runID) //nolint: contextcheck
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (g *IngestorAPI) Ingest(_ context.Context, clusterName string, runID string
 	return nil
 }
 
-func (g *IngestorAPI) isAlreadyIngested(ctx context.Context, clusterName string, runID string) (bool, error) {
+func (g *IngestorAPI) isAlreadyIngestedDB(ctx context.Context, clusterName string, runID string) (bool, error) {
 	var resNum int64
 	var err error
 	for _, collection := range collections.GetCollections() {
@@ -161,7 +161,7 @@ func (g *IngestorAPI) isAlreadyIngested(ctx context.Context, clusterName string,
 
 			return true, nil
 		}
-		log.I.Infof("Found %d element in collection %s", resNum, collection)
+		log.I.Debugf("Found %d element in collection %s", resNum, collection)
 	}
 
 	return false, nil

--- a/pkg/ingestor/api/api_test.go
+++ b/pkg/ingestor/api/api_test.go
@@ -163,7 +163,6 @@ func TestIngestorAPI_isAlreadyIngested(t *testing.T) {
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
 	ctx := context.TODO()
-	mockStoreProvider := mocksStore.NewProvider(t)
 
 	type fields struct {
 		providers *providers.ProvidersFactoryConfig
@@ -186,7 +185,7 @@ func TestIngestorAPI_isAlreadyIngested(t *testing.T) {
 			fields: fields{
 				mock: mt,
 				providers: &providers.ProvidersFactoryConfig{
-					StoreProvider: mockStoreProvider,
+					StoreProvider: mocksStore.NewProvider(t),
 				},
 			},
 			args: args{
@@ -202,7 +201,7 @@ func TestIngestorAPI_isAlreadyIngested(t *testing.T) {
 			fields: fields{
 				mock: mt,
 				providers: &providers.ProvidersFactoryConfig{
-					StoreProvider: mockStoreProvider,
+					StoreProvider: mocksStore.NewProvider(t),
 				},
 			},
 			args: args{
@@ -223,7 +222,7 @@ func TestIngestorAPI_isAlreadyIngested(t *testing.T) {
 			}
 
 			tt.testfct(mt, g)
-			alreadyIngested, err := g.isAlreadyIngested(ctx, tt.args.clusterName, tt.args.runID)
+			alreadyIngested, err := g.isAlreadyIngestedDB(ctx, tt.args.clusterName, tt.args.runID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s - IngestorAPI.checkPreviousRun() error = %d, wantErr %v", tt.name, err, tt.wantErr)
 			}

--- a/pkg/ingestor/api/api_test.go
+++ b/pkg/ingestor/api/api_test.go
@@ -158,7 +158,7 @@ func TestIngestorAPI_Ingest(t *testing.T) {
 	}
 }
 
-func TestIngestorAPI_isAlreadyIngested(t *testing.T) {
+func TestIngestorAPI_isAlreadyIngestedInDB(t *testing.T) {
 	t.Parallel()
 	mt := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
 
@@ -222,7 +222,7 @@ func TestIngestorAPI_isAlreadyIngested(t *testing.T) {
 			}
 
 			tt.testfct(mt, g)
-			alreadyIngested, err := g.isAlreadyIngestedDB(ctx, tt.args.clusterName, tt.args.runID)
+			alreadyIngested, err := g.isAlreadyIngestedInDB(ctx, tt.args.clusterName, tt.args.runID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s - IngestorAPI.checkPreviousRun() error = %d, wantErr %v", tt.name, err, tt.wantErr)
 			}


### PR DESCRIPTION
Fixing race condition on `TestIngestorAPI_isAlreadyIngested`.

running no longer trigger errors:
* ` go test -timeout 30s -run ^TestIngestorAPI_isAlreadyIngested$ github.com/DataDog/KubeHound/pkg/ingestor/api -v -race -count 20`