### PR TITLE
Add custom filter for text_formatter

### DIFF
--- a/pkg/telemetry/log/logger.go
+++ b/pkg/telemetry/log/logger.go
@@ -125,6 +125,8 @@ func Trace(ctx context.Context, opts ...LoggerOption) *KubehoundLogger {
 }
 
 func GetLogrusFormatter() logrus.Formatter {
+	customTextFormatter := NewFilteredTextFormatter(DefaultRemovedFields)
+
 	switch logFormat := os.Getenv("KH_LOG_FORMAT"); {
 	// Datadog require the logged field to be "message" and not "msg"
 	case logFormat == "dd":
@@ -138,8 +140,8 @@ func GetLogrusFormatter() logrus.Formatter {
 	case logFormat == "json":
 		return &logrus.JSONFormatter{}
 	case logFormat == "text":
-		return &logrus.TextFormatter{}
+		return customTextFormatter
 	default:
-		return &logrus.TextFormatter{}
+		return customTextFormatter
 	}
 }

--- a/pkg/telemetry/log/text_formatter.go
+++ b/pkg/telemetry/log/text_formatter.go
@@ -1,0 +1,36 @@
+package log
+
+import (
+	"time"
+
+	logrus "github.com/sirupsen/logrus"
+)
+
+var (
+	DefaultRemovedFields = []string{"component", "team", "service"}
+)
+
+// FilteredTextFormatter is a logrus.TextFormatter that filters out some specific fields that are not needed for humans.
+// These fields are usually more helpful for machines, and with json formatting for example.
+type FilteredTextFormatter struct {
+	tf            logrus.TextFormatter
+	removedFields []string
+}
+
+func NewFilteredTextFormatter(removedFields []string) logrus.Formatter {
+	return &FilteredTextFormatter{
+		tf: logrus.TextFormatter{
+			FullTimestamp:   true,
+			TimestampFormat: time.TimeOnly,
+		},
+		removedFields: removedFields,
+	}
+}
+
+func (f *FilteredTextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	for _, field := range f.removedFields {
+		delete(entry.Data, field)
+	}
+
+	return f.tf.Format(entry)
+}

--- a/pkg/telemetry/log/text_formatter.go
+++ b/pkg/telemetry/log/text_formatter.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	DefaultRemovedFields = []string{"component", "team", "service"}
+	DefaultRemovedFields = []string{"component", "team", "service", "run_id"}
 )
 
 // FilteredTextFormatter is a logrus.TextFormatter that filters out some specific fields that are not needed for humans.


### PR DESCRIPTION
In order to make console output more user friendly, lets remove some fields that are unnecessary for human consumption (team, component, service). `run_id` is already printed for "typical use cases" in the logs, so removing it as well.