### PR TITLE
Run Datadog static analyzer CI best practices lint rules

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -1,0 +1,25 @@
+name: Datadog Static Analysis
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  static-analysis:
+    name: Datadog Static Analyzer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check code meets quality and security standards
+        id: datadog-static-analysis
+        uses: DataDog/datadog-static-analyzer-github-action@v1
+        with:
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          dd_app_key: ${{ secrets.DD_APP_KEY }}
+          dd_service: kubehound
+          dd_env: ci
+          dd_site: datadoghq.com
+          cpu_count: 2

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   static-analysis:

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,4 +1,7 @@
 rulesets:
   - go-best-practices
   - go-security
+  - sit-ci-best-practices:
+    only:
+      - ".github/workflows"
 ignorePaths: []


### PR DESCRIPTION
This PR adds a GitHub action to run the Datadog static analysis product.