### PR TITLE
adding grpcurl to rehydrate on restart

### DIFF
--- a/deployments/kubehound/kubegraph/Dockerfile
+++ b/deployments/kubehound/kubegraph/Dockerfile
@@ -28,6 +28,9 @@ COPY --chown=janusgraph:janusgraph scripts/health-check.groovy ${JANUS_HOME}/scr
 # DSL support
 COPY --chown=janusgraph:janusgraph scripts/kubehound-dsl-init.groovy ${JANUS_HOME}/scripts/
 
+# grpcurl to rehydrate dumps on startup
+COPY --from=fullstorydev/grpcurl:v1.9.1 --chown=janusgraph:janusgraph /bin/grpcurl /usr/local/bin/grpcurl
+
 # Set JVM configuration
 ENV JAVA_OPTIONS_FILE ${JANUS_HOME}/conf/jvm.options
 


### PR DESCRIPTION
Adding grpcurl to allow rehydrating on restart.

It does not do the rehydration, it has to add ` grpcurl -plaintext -format text 127.0.0.1:9000 grpc.API.RehydrateLatest`  in the startup scripts. 