### PR TITLE
Fix-darwin-arm-release

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -86,7 +86,7 @@ jobs:
         name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: compose
+          name: kubehound
           path: ./bin/release/*
           if-no-files-found: error
 
@@ -105,7 +105,7 @@ jobs:
         name: Download artifacts
         uses: actions/download-artifact@v3
         with:
-          name: compose
+          name: kubehound
           path: bin/release
       -
         name: Create checksums

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,8 @@ RUN --mount=from=binary \
     mkdir -p /out && \
     # TODO: should just use standard arch
     TARGETARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "$TARGETARCH"); \
-    TARGETARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "$TARGETARCH"); \
+    # Use arm64 for darwin
+    TARGETARCH=$([ "$TARGETARCH" = "arm64" ] && [ "$TARGETOS" != "darwin" ] && echo "aarch64" || echo "$TARGETARCH"); \
     cp kubehound* "/out/kubehound-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}$(ls kubehound* | sed -e 's/^kubehound//')"
 
 FROM scratch AS release


### PR DESCRIPTION
In order to "enable" the one liner installer `wget https://github.com/DataDog/KubeHound/releases/download/latest/kubehound-$(uname -o | sed 's/GNU\///g')-$(uname -m) -O kubehound` we need to modify the `darwin-aarch` to `darwin-arm64`.