### PR TITLE
local-ingest-dump-pipeline

### DIFF
--- a/cmd/kubehound/backend.go
+++ b/cmd/kubehound/backend.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/DataDog/KubeHound/pkg/backend"
 	docker "github.com/DataDog/KubeHound/pkg/backend"
 	"github.com/spf13/cobra"
 )
@@ -11,7 +10,7 @@ var (
 	hard        bool
 	composePath []string
 
-	uiProfile = backend.DefaultUIProfile
+	uiProfile = docker.DefaultUIProfile
 	uiInvana  bool
 )
 

--- a/cmd/kubehound/dumper.go
+++ b/cmd/kubehound/dumper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/DataDog/KubeHound/pkg/backend"
 	docker "github.com/DataDog/KubeHound/pkg/backend"
 	"github.com/DataDog/KubeHound/pkg/cmd"
 	"github.com/DataDog/KubeHound/pkg/config"
@@ -92,7 +91,7 @@ var (
 			}
 
 			if startBackend {
-				err = docker.NewBackend(cobraCmd.Context(), composePath, backend.DefaultUIProfile)
+				err = docker.NewBackend(cobraCmd.Context(), composePath, docker.DefaultUIProfile)
 				if err != nil {
 					return fmt.Errorf("new backend: %w", err)
 				}

--- a/pkg/dump/pipeline/pipeline.go
+++ b/pkg/dump/pipeline/pipeline.go
@@ -149,6 +149,7 @@ func dumpK8sObjs(ctx context.Context, operationName string, entity string, strea
 	var err error
 	defer func() { span.Finish(tracer.WithError(err)) }()
 	err = streamFunc(ctx)
+	log.I.Infof("Dumping %s done", entity)
 
 	return ctx, err
 }

--- a/pkg/kubehound/core/core_grpc_client.go
+++ b/pkg/kubehound/core/core_grpc_client.go
@@ -41,6 +41,8 @@ func CoreClientGRPCIngest(ingestorConfig config.IngestorConfig, clusteName strin
 	defer conn.Close()
 	client := pb.NewAPIClient(conn)
 
+	log.I.Infof("Launching ingestion on %s [rundID: %s]", ingestorConfig.API.Endpoint, runID)
+
 	_, err = client.Ingest(context.Background(), &pb.IngestRequest{
 		RunId:       runID,
 		ClusterName: clusteName,


### PR DESCRIPTION
Adding flags to start the ingestion after a local dump:
* `--ingest`: to start the ingestion
* `--backend`: to start the backend

Also added some logs based some users feedback to let the user know how the dump/ingest is progressing.