### PR TITLE
Jt-dd/fixes-release-docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,9 @@ RUN --mount=from=binary \
     TARGETARCH=$([ "$TARGETARCH" = "amd64" ] && echo "x86_64" || echo "$TARGETARCH"); \
     # Use arm64 for darwin
     TARGETARCH=$([ "$TARGETARCH" = "arm64" ] && [ "$TARGETOS" != "darwin" ] && echo "aarch64" || echo "$TARGETARCH"); \
+    # Upper case first letter to match the uname -o output
+    TARGETOS=$([ "$TARGETOS" = "darwin" ] && echo "Darwin" || echo "$TARGETOS"); \
+    TARGETOS=$([ "$TARGETOS" = "linux" ] && echo "Linux" || echo "$TARGETOS"); \
     cp kubehound* "/out/kubehound-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}$(ls kubehound* | sed -e 's/^kubehound//')"
 
 FROM scratch AS release

--- a/docs/dev-guide/getting-started.md
+++ b/docs/dev-guide/getting-started.md
@@ -156,9 +156,11 @@ To list all the available commands, run:
 make help
 ```
 
-Note: if you are running on Linux but you dont want to run `sudo` for `kind` and `docker` command, you can overwrite this behavior by editing the following var in `test/setup/.config`:
-* `DOCKER_CMD="docker"` for docker command
-* `KIND_CMD="kind"` for kind command 
+!!! Note
+    if you are running on Linux but you dont want to run `sudo` for `kind` and `docker` command, you can overwrite this behavior by editing the following var in `test/setup/.config`:
+    
+    * `DOCKER_CMD="docker"` for docker command
+    * `KIND_CMD="kind"` for kind command 
 
 #### CI Testing
 


### PR DESCRIPTION
Fix:
* UI typo in the doc
* Fix the upper case to match the `uname -o` output