### PR TITLE
Fix workflows RBAC

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 permissions:
-  contents: write # write permission is needed to get access to the DD_API_KEY secrete - https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#accessing-your-secrets
+  contents: write # write permission is needed to get access to the DD_API_KEY secret - https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#accessing-your-secrets
 
 jobs:
   static-analysis:

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 permissions:
-  contents: write
+  contents: write # write permission is needed to get access to the DD_API_KEY secrete - https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#accessing-your-secrets
 
 jobs:
   static-analysis:

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   system-test:
     runs-on:


### PR DESCRIPTION
Reduce default privileges on the `GITHUB_TOKEN`. Limit the scope to `Read repository contents and packages permissions`.

Adding permission manually to each workflows.