### PR TITLE
Fix datadog agent release

### DIFF
--- a/pkg/backend/project.go
+++ b/pkg/backend/project.go
@@ -20,7 +20,6 @@ import (
 
 var (
 	DefaultReleaseComposePaths = []string{"docker-compose.yaml", "docker-compose.release.yaml.tpl"}
-	DefaultDatadogComposePath  = "docker-compose.release.datadog.yaml"
 	DefaultUIProfile           = []string{DevUIProfile}
 
 	DevUIProfile = "jupyter"
@@ -89,17 +88,8 @@ func loadEmbeddedConfig(ctx context.Context, profiles []string) (*types.Project,
 	var hostname string
 
 	// Adding datadog setup
-	ddAPIKey, ddAPIKeyOk := os.LookupEnv("DD_API_KEY")
-	ddAPPKey, ddAPPKeyOk := os.LookupEnv("DD_API_KEY")
-
-	if ddAPIKeyOk && ddAPPKeyOk {
-		DefaultReleaseComposePaths = append(DefaultReleaseComposePaths, DefaultDatadogComposePath)
-		hostname, err = os.Hostname()
-		if err != nil {
-			hostname = "kubehound"
-		}
-
-	}
+	ddAPIKey, _ := os.LookupEnv("DD_API_KEY")
+	ddAPPKey, _ := os.LookupEnv("DD_API_KEY")
 
 	for i, filePath := range DefaultReleaseComposePaths {
 		dockerComposeFileData, err = loadEmbeddedDockerCompose(ctx, filePath, dockerComposeFileData)

--- a/pkg/backend/project.go
+++ b/pkg/backend/project.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"text/template"
 
@@ -85,11 +84,6 @@ func loadComposeConfig(ctx context.Context, composeFilePaths []string, profiles 
 func loadEmbeddedConfig(ctx context.Context, profiles []string) (*types.Project, error) {
 	var dockerComposeFileData map[interface{}]interface{}
 	var err error
-	var hostname string
-
-	// Adding datadog setup
-	ddAPIKey, _ := os.LookupEnv("DD_API_KEY")
-	ddAPPKey, _ := os.LookupEnv("DD_API_KEY")
 
 	for i, filePath := range DefaultReleaseComposePaths {
 		dockerComposeFileData, err = loadEmbeddedDockerCompose(ctx, filePath, dockerComposeFileData)
@@ -108,11 +102,6 @@ func loadEmbeddedConfig(ctx context.Context, profiles []string) (*types.Project,
 			{
 				Content: data,
 			},
-		},
-		Environment: map[string]string{
-			"DD_API_KEY":      ddAPIKey,
-			"DD_APP_KEY":      ddAPPKey,
-			"DOCKER_HOSTNAME": hostname,
 		},
 	}
 


### PR DESCRIPTION
As #251 mention when running KubeHound with `DD_APP_KEY` and `DD_API_KEY`, it crashes since we are mounting volumes from the embed files.

So if the key are being set, we assume the agent is already running anyway. The Datadog agent can still be launched using the `dev` files/cmd.