### PR TITLE
Fix-ci-release-branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine AS base
 COPY --from=xx / /
 RUN apk add --no-cache \
-      clang \
-      docker \
-      file \
-      findutils \
-      git \
-      make \
-      protoc \
-      protobuf-dev
+    clang \
+    docker \
+    file \
+    findutils \
+    git \
+    make \
+    protoc \
+    protobuf-dev
 WORKDIR /src
 ENV CGO_ENABLED=0
 
@@ -49,8 +49,10 @@ RUN --mount=type=bind,target=.,rw \
 
 FROM build-base AS build
 ARG BUILD_TAGS
+ARG BUILD_BRANCH
 ARG BUILD_FLAGS
 ARG TARGETPLATFORM
+ENV BUILD_BRANCH="${BUILD_BRANCH}"
 RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_ARCH := $(shell go env GOARCH)
 BUILD_OS := $(shell go env GOOS)
 
-BUILD_FLAGS := -ldflags="-X github.com/DataDog/KubeHound/pkg/config.BuildVersion=$(BUILD_VERSION) -X github.com/DataDog/KubeHound/pkg/config.BuildBranch=$(BUILD_BRANCH) -X github.com/DataDog/KubeHound/pkg/config.BuildArch=$(BUILD_ARCH) -X github.com/DataDog/KubeHound/pkg/config.BuildOs=$(BUILD_OS) -s -w"
+BUILD_FLAGS := -ldflags="-X github.com/DataDog/KubeHound/pkg/config.BuildVersion=$(BUILD_VERSION) -X github.com/DataDog/KubeHound/pkg/config.BuildBranch=$(BUILD_BRANCH) -X github.com/DataDog/KubeHound/pkg/config.BuildArch=$(BUILD_ARCH) -X github.com/DataDog/KubeHound/pkg/config.BuildOs=$(BUILD_OS)"
 
 # Need to save the MAKEFILE_LIST variable before the including the env var files
 HELP_MAKEFILE_LIST := $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_ARCH := $(shell go env GOARCH)
 BUILD_OS := $(shell go env GOOS)
 
-BUILD_FLAGS := -ldflags="-X github.com/DataDog/KubeHound/pkg/config.BuildVersion=$(BUILD_VERSION) -X github.com/DataDog/KubeHound/pkg/config.BuildBranch=$(BUILD_BRANCH) -X github.com/DataDog/KubeHound/pkg/config.BuildArch=$(BUILD_ARCH) -X github.com/DataDog/KubeHound/pkg/config.BuildOs=$(BUILD_OS)"
+BUILD_FLAGS := -ldflags="-X github.com/DataDog/KubeHound/pkg/config.BuildVersion=$(BUILD_VERSION) -X github.com/DataDog/KubeHound/pkg/config.BuildBranch=$(BUILD_BRANCH) -X github.com/DataDog/KubeHound/pkg/config.BuildArch=$(BUILD_ARCH) -X github.com/DataDog/KubeHound/pkg/config.BuildOs=$(BUILD_OS) -s -w"
 
 # Need to save the MAKEFILE_LIST variable before the including the env var files
 HELP_MAKEFILE_LIST := $(MAKEFILE_LIST)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -60,6 +60,10 @@ target "binary-cross" {
 }
 
 target "release" {
+  # Overrinding the branch as this target is only being used in the CI
+  args = {
+    BUILD_BRANCH = "main"
+  }
   inherits = ["binary-cross"]
   target = "release"
   output = [outdir("./bin/release")]


### PR DESCRIPTION
The binary in the release page are using the latest flag. 

```
INFO[21:02:00] Loading application configuration from default embedded
INFO[21:02:00] Initializing application telemetry
WARN[21:02:00] Telemetry disabled via configuration
INFO[21:02:00] Loading backend from default embedded
WARN[21:02:00] Loading the kubehound images with tag latest - dev branch detected
INFO[21:02:00] Spawning the kubehound stack
```

This behavior should be kept only for the dev or locally build of KubeHound.

Note: this behavior is not detected in brew release for some reasons ...