### PR TITLE
Fix buildx pipeline for Darwin binary/image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,9 @@ RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=bind,from=osxcross,src=/osxsdk,target=/xx-sdk \
     xx-go --wrap && \
-    if [ "$(xx-info os)" == "darwin" ]; then export CGO_ENABLED=1; fi && \
+    # Removing DWARD symbol on Darwin as it causes the following error:
+    # /usr/local/go/pkg/tool/linux_arm64/link: /usr/local/go/pkg/tool/linux_arm64/link: running dsymutil failed: exec: "dsymutil": executable file not found in $PATH
+    if [ "$(xx-info os)" == "darwin" ]; then export CGO_ENABLED=1; export BUILD_TAGS="-w $BUILD_TAGS"; fi && \
     make build GO_BUILDTAGS="$BUILD_TAGS" DESTDIR=/out && \
     xx-verify --static /out/kubehound
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_ARCH := $(shell go env GOARCH)
 BUILD_OS := $(shell go env GOOS)
 
-BUILD_FLAGS := -ldflags="-X github.com/DataDog/KubeHound/pkg/config.BuildVersion=$(BUILD_VERSION) -X github.com/DataDog/KubeHound/pkg/config.BuildBranch=$(BUILD_BRANCH) -X github.com/DataDog/KubeHound/pkg/config.BuildArch=$(BUILD_ARCH) -X github.com/DataDog/KubeHound/pkg/config.BuildOs=$(BUILD_OS)"
+BUILD_FLAGS := -ldflags="${GO_BUILDTAGS} -X github.com/DataDog/KubeHound/pkg/config.BuildVersion=$(BUILD_VERSION) -X github.com/DataDog/KubeHound/pkg/config.BuildBranch=$(BUILD_BRANCH) -X github.com/DataDog/KubeHound/pkg/config.BuildArch=$(BUILD_ARCH) -X github.com/DataDog/KubeHound/pkg/config.BuildOs=$(BUILD_OS)"
 
 # Need to save the MAKEFILE_LIST variable before the including the env var files
 HELP_MAKEFILE_LIST := $(MAKEFILE_LIST)


### PR DESCRIPTION
Removing DWARF symbol on Darwin as it causes the following error:
* Pipeline: darwin/amd64 - https://github.com/DataDog/KubeHound/actions/runs/10827132520/job/30039621994
* Pipeline: darwin/arm64 - https://github.com/DataDog/KubeHound/actions/runs/10827132520/job/30039622608


```
/usr/local/go/pkg/tool/linux_arm64/link: /usr/local/go/pkg/tool/linux_arm64/link: running dsymutil failed: exec: "dsymutil": executable file not found in $PATH
```

So striping the DWARF symbol just for the Darwin Binary.