### PR TITLE
fix kubehound image name

### DIFF
--- a/deployments/kubehound/docker-compose.release.ingestor.yaml
+++ b/deployments/kubehound/docker-compose.release.ingestor.yaml
@@ -1,7 +1,7 @@
 name: kubehound-release
 services:
   grpc:
-    image: ghcr.io/datadog/kubehound-ingestor:latest
+    image: ghcr.io/datadog/kubehound-binary:latest
     restart: unless-stopped
     ports:
       - "127.0.0.1:9000:9000"


### PR DESCRIPTION
Fix kubehound image name as it changed to kubehound-binary with `v1.5.0` release