### PR TITLE
fix grpc ingestor (backward compat)

### DIFF
--- a/cmd/kubehound/ingest.go
+++ b/cmd/kubehound/ingest.go
@@ -74,9 +74,9 @@ var (
 	}
 )
 
+// If no arg is provided, run the reHydration of the latest snapshots (stored in KHaaS / S3 Bucket)
 func isIngestRemoteDefault() bool {
-	runID := viper.GetString(config.IngestorRunID)
-	clusterName := viper.GetString(config.IngestorClusterName)
+	clusterName := viper.GetString(config.DynamicClusterName)
 
 	return runID == "" && clusterName == ""
 }

--- a/pkg/config/ingestor.go
+++ b/pkg/config/ingestor.go
@@ -10,8 +10,6 @@ const (
 
 	IngestorAPIEndpoint    = "ingestor.api.endpoint"
 	IngestorAPIInsecure    = "ingestor.api.insecure"
-	IngestorClusterName    = "ingestor.cluster_name"
-	IngestorRunID          = "ingestor.run_id"
 	IngestorMaxArchiveSize = "ingestor.max_archive_size"
 	IngestorTempDir        = "ingestor.temp_dir"
 	IngestorArchiveName    = "ingestor.archive_name"

--- a/pkg/ingestor/api/api.go
+++ b/pkg/ingestor/api/api.go
@@ -124,7 +124,7 @@ func (g *IngestorAPI) Ingest(_ context.Context, path string) error {
 	if err != nil {
 		log.I.Warnf("no metadata has been parsed (old dump format from v1.4.0 or below do not embed metadata information): %v", err)
 		// Backward Compatibility: Extracting the metadata from the path
-		dumpMetadata, err := dump.ParsePath(archivePath)
+		dumpMetadata, err := dump.ParsePath(path)
 		if err != nil {
 			log.I.Warn("parsing path for metadata", err)
 


### PR DESCRIPTION
With the introduction of `metadata.json` in v1.5.0, we need to have retro compatibility with old dumps. So I clean the old args and patch with the key path to extract the metadata information.