### PR TITLE
Fix fork based PR system-test

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -12,11 +12,11 @@ permissions:
 jobs:
   system-test:
     runs-on:
-      group: Large Runner Shared Public 
+      group: Large Runner Shared Public
       labels: ubuntu-8-core-latest
     services:
       dd-agent:
-        image: gcr.io/datadoghq/agent:7
+        image: ${{ (! github.event.pull_request.head.repo.fork ) && 'gcr.io/datadoghq/agent:7' || '' }}
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
           DD_TRACE_DEBUG: 1
@@ -46,7 +46,7 @@ jobs:
             gcr.io:443
             repo.maven.apache.org:443
             *.datadoghq.com:443
-          
+
       - name: Checkout Git Repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
@@ -58,12 +58,12 @@ jobs:
           wait: 5m
         env:
           KUBECONFIG: ./test/setup/.kube-config
-        
+
       - name: Create K8s resources
         run: make local-cluster-resource-deploy
         env:
           KUBECONFIG: ./test/setup/.kube-config
-      
+
       - name: Setup Golang
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:


### PR DESCRIPTION
Running datadog agent only on branch based PR. As if is not supported yet by Github, the following workaround is possible:

* https://github.com/actions/runner/issues/822