### PR TITLE
Fix for collector in k8s environment

### DIFF
--- a/pkg/config/k8s.go
+++ b/pkg/config/k8s.go
@@ -3,8 +3,15 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
 
+	"github.com/DataDog/KubeHound/pkg/telemetry/log"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	clusterNameEnvVarPtr = "KH_K8S_CLUSTER_NAME_ENV_PTR"
+	clusterNameEnvVar    = "KH_K8S_CLUSTER_NAME"
 )
 
 // ClusterInfo encapsulates the target cluster information for the current run.
@@ -13,6 +20,22 @@ type ClusterInfo struct {
 }
 
 func NewClusterInfo(_ context.Context) (*ClusterInfo, error) {
+	// Testing if running from pod
+	// Using an environment variable to get the cluster name as it is not provided in the pod configuration
+	clusterNamePtr := os.Getenv(clusterNameEnvVarPtr)
+	clusterName := os.Getenv(clusterNameEnvVar)
+	if clusterNamePtr != "" {
+		clusterName = os.Getenv(clusterNamePtr)
+	}
+	if clusterName != "" {
+		log.I.Warnf("Using cluster name from environment variable [%s]: %s", clusterNameEnvVar, clusterName)
+
+		return &ClusterInfo{
+			Name: clusterName,
+		}, nil
+	}
+
+	// Testing if running from outside the cluster
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)


### PR DESCRIPTION
When deploying the collector inside a k8s cluster, we need to configure one of the two variable:

- `KH_K8S_CLUSTER_NAME_ENV_PTR`: variable indicating env var to use from the k8s cluster/pod to setup the name of the targetted k8s cluster
- `KH_K8S_CLUSTER_NAME`: variable indicating the name of the targetted k8s cluster

Note:
* `KH_K8S_CLUSTER_NAME_ENV_PTR` will overwrite the `KH_K8S_CLUSTER_NAME` env var.