### PR TITLE
Rename remote bucket flag to bucket-url

### DIFF
--- a/pkg/cmd/dump.go
+++ b/pkg/cmd/dump.go
@@ -37,8 +37,8 @@ func InitLocalDumpCmd(cmd *cobra.Command) {
 }
 
 func InitRemoteDumpCmd(cmd *cobra.Command) {
-	cmd.Flags().String("bucket", "", "Bucket to use to push k8s resources (e.g.: s3://<your_bucket>)")
-	viper.BindPFlag(config.CollectorFileBlobBucket, cmd.Flags().Lookup("bucket")) //nolint: errcheck
+	cmd.Flags().String("bucket-url", "", "Bucket to use to push k8s resources (e.g.: s3://<your_bucket>)")
+	viper.BindPFlag(config.CollectorFileBlobBucket, cmd.Flags().Lookup("bucket-url")) //nolint: errcheck
 
 	cmd.Flags().String("region", "", "Region to retrieve the configuration (only for s3) (e.g.: us-east-1)")
 	viper.BindPFlag(config.CollectorFileBlobRegion, cmd.Flags().Lookup("region")) //nolint: errcheck


### PR DESCRIPTION
To match the config file, renaming `--bucket` to `--bucket-url` as an URL is asked as input (i.e. s3://<your_bucket>).