### PR TITLE
fixing waiting time metric

### DIFF
--- a/pkg/collector/k8s_api.go
+++ b/pkg/collector/k8s_api.go
@@ -150,11 +150,11 @@ func (c *k8sAPICollector) ComputeMetadata(ctx context.Context, ingestor Metadata
 }
 
 func (c *k8sAPICollector) wait(_ context.Context, resourceType string, tags []string) {
+	c.mu.Lock()
 	prev := time.Now()
 	now := c.rl.Take()
 
 	waitTime := now.Sub(prev)
-	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.waitTime[resourceType] += waitTime
 


### PR DESCRIPTION
Fixing waiting time metric.

before:
```
INFO[11:53:08] Dumping Metadata                             
INFO[11:53:08] Stats for the run time duration: 57.097094292s / wait: 3m11.202109s / throttling: 334.871873% 
INFO[11:53:08] Dumping Metadata done          
INFO[11:53:09] KubeHound dump run has been completed in 58.66889575s          
```

after:
```
INFO[12:07:15] Dumping Metadata                             
INFO[12:07:15] Stats for the run time duration: 5m19.270919416s / wait: 4m54.122048s / throttling: 92.123031% 
INFO[12:07:15] Dumping Metadata done                        
INFO[12:07:18] KubeHound dump run has been completed in 5m43.414716208s 
```