### PR TITLE
adding nocache flag for dev commands

### DIFF
--- a/cmd/kubehound/dev.go
+++ b/cmd/kubehound/dev.go
@@ -20,6 +20,7 @@ var (
 var (
 	uiTesting   bool
 	grpcTesting bool
+	noCache     bool
 	downTesting bool
 	profiles    []string
 )
@@ -71,7 +72,7 @@ func runEnv(ctx context.Context, composePaths []string) error {
 		return docker.Down(ctx)
 	}
 
-	return docker.BuildUp(ctx)
+	return docker.BuildUp(ctx, noCache)
 }
 
 func init() {
@@ -79,6 +80,7 @@ func init() {
 	envCmd.PersistentFlags().BoolVar(&downTesting, "down", false, "Tearing down the kubehound dev stack and deleting the data associated with it")
 	envCmd.Flags().BoolVar(&uiTesting, "ui", false, "Include the UI in the dev stack")
 	envCmd.Flags().BoolVar(&grpcTesting, "grpc", false, "Include Grpc Server (ingestor) in the dev stack")
+	envCmd.Flags().BoolVar(&noCache, "no-cache", false, "Disable the cache when building the images")
 
 	rootCmd.AddCommand(envCmd)
 }

--- a/cmd/kubehound/server.go
+++ b/cmd/kubehound/server.go
@@ -15,7 +15,7 @@ var (
 		Long:         `instance of Kubehound that pulls data from cloud storage`,
 		SilenceUsage: true,
 		PersistentPreRunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), cfgFile, true, false)
+			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), cfgFile, false, false)
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Passing the Kubehound config from viper

--- a/deployments/kubehound/docker-compose.dev.ui.yaml
+++ b/deployments/kubehound/docker-compose.dev.ui.yaml
@@ -1,7 +1,7 @@
 name: kubehound-dev
 services:
   ui-jupyter:
-    build: ./notebook/
+    build: ./ui/
     restart: unless-stopped
     volumes:
       - ./notebook/shared:/root/notebooks/shared

--- a/pkg/backend/containers.go
+++ b/pkg/backend/containers.go
@@ -66,14 +66,14 @@ func newDockerCli() (*command.DockerCli, error) {
 	return dockerCli, nil
 }
 
-func BuildUp(ctx context.Context) error {
-	return currentBackend.buildUp(ctx)
+func BuildUp(ctx context.Context, noCache bool) error {
+	return currentBackend.buildUp(ctx, noCache)
 }
 
-func (b *Backend) buildUp(ctx context.Context) error {
+func (b *Backend) buildUp(ctx context.Context, noCache bool) error {
 	log.I.Infof("Building the kubehound stack")
 	err := b.composeService.Build(ctx, b.project, api.BuildOptions{
-		NoCache: true,
+		NoCache: noCache,
 		Pull:    true,
 	})
 	if err != nil {


### PR DESCRIPTION
Adding --no-cache for dev command: `kubehound dev --ui --no-cache`. The default behavior now is to use cache when building Docker images.

This avoid spending 10 minutes building the UI...
