### PR TITLE
doc(requirements): add memory requirements for docker machine.

### DIFF
--- a/docs/dev-guide/getting-started.md
+++ b/docs/dev-guide/getting-started.md
@@ -8,6 +8,7 @@ make help
 
 ## Requirements build
 
+- 16GB of RAM (minimum)
 - go (v1.23): https://go.dev/doc/install
 - [Docker](https://docs.docker.com/engine/install/) >= 19.03 (`docker version`)
 - [Docker Compose](https://docs.docker.com/compose/compose-file/compose-versioning/) >= v2.0 (`docker compose version`)


### PR DESCRIPTION
# Context

Inform the user that the minimum docker/podman machine must have at least 16GB allocated to prevent bootstrap issues of JVM processes.