### PR TITLE
Fix umh core pattern attacks

### DIFF
--- a/pkg/kubehound/storage/storedb/index_builder.go
+++ b/pkg/kubehound/storage/storedb/index_builder.go
@@ -123,6 +123,14 @@ func (ib *IndexBuilder) containers(ctx context.Context) error {
 			},
 			Options: options.Index().SetName("byRun"),
 		},
+		{
+			Keys: bson.D{
+				{Key: "k8.securitycontext.runasuser", Value: 1},
+				{Key: "runtime.runID", Value: 1},
+				{Key: "runtime.cluster", Value: 1},
+			},
+			Options: options.Index().SetName("byRunAsUser"),
+		},
 	}
 
 	_, err := containers.Indexes().CreateMany(ctx, indices)


### PR DESCRIPTION
The `umh_core_pattern` attack is currently linking the attack to all volumes which generates a lot of false positive.

Updating the MongoDB request to link only vulnerable volumes.