### PR TITLE
Removed the use of labels for perf reasons

### DIFF
--- a/deployments/kubehound/graph/dsl/kubehound/src/main/java/com/datadog/ase/kubehound/KubeHoundTraversalSourceDsl.java
+++ b/deployments/kubehound/graph/dsl/kubehound/src/main/java/com/datadog/ase/kubehound/KubeHoundTraversalSourceDsl.java
@@ -60,13 +60,14 @@ public class KubeHoundTraversalSourceDsl extends GraphTraversalSource {
 
         if (names.length > 0) {
             traversal = traversal.has("cluster", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices from the specified KubeHound run(s)
+     * Starts a traversal that finds all vertices from the specified KubeHound
+     * run(s)
      *
      * @param ids list of run ids to filter on
      */
@@ -75,13 +76,14 @@ public class KubeHoundTraversalSourceDsl extends GraphTraversalSource {
 
         if (ids.length > 0) {
             traversal = traversal.has("runID", P.within(ids));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "Container" label and optionally allows filtering of those
+     * Starts a traversal that finds all vertices with a "Container" label and
+     * optionally allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of container names to filter on
@@ -89,16 +91,17 @@ public class KubeHoundTraversalSourceDsl extends GraphTraversalSource {
     public GraphTraversal<Vertex, Vertex> containers(String... names) {
         GraphTraversal traversal = this.clone().V();
 
-        traversal = traversal.hasLabel("Container");
+        traversal = traversal.has("class", "Container");
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "Pod" label and optionally allows filtering of those
+     * Starts a traversal that finds all vertices with a "Pod" label and optionally
+     * allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of pod names to filter on
@@ -106,16 +109,17 @@ public class KubeHoundTraversalSourceDsl extends GraphTraversalSource {
     public GraphTraversal<Vertex, Vertex> pods(String... names) {
         GraphTraversal traversal = this.clone().V();
 
-        traversal = traversal.hasLabel("Pod");
+        traversal = traversal.has("class", "Pod");
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "Node" label and optionally allows filtering of those
+     * Starts a traversal that finds all vertices with a "Node" label and optionally
+     * allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of node names to filter on
@@ -123,33 +127,35 @@ public class KubeHoundTraversalSourceDsl extends GraphTraversalSource {
     public GraphTraversal<Vertex, Vertex> nodes(String... names) {
         GraphTraversal traversal = this.clone().V();
 
-        traversal = traversal.hasLabel("Node");
+        traversal = traversal.has("class", "Node");
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all container escape edges from a Container vertex to a Node vertex 
-     * and optionally allows filtering of those vertices on the "nodeNames" property.
+     * Starts a traversal that finds all container escape edges from a Container
+     * vertex to a Node vertex
+     * and optionally allows filtering of those vertices on the "nodeNames"
+     * property.
      *
      * @param nodeNames list of node names to filter on
-
+     * 
      */
     public GraphTraversal<Vertex, Path> escapes(String... nodeNames) {
         GraphTraversal traversal = this.clone().V();
 
         traversal = traversal
-            .hasLabel("Container")
-            .outE()
-            .inV()
-            .hasLabel("Node");
+                .has("class", "Container")
+                .outE()
+                .inV()
+                .has("class", "Node");
 
         if (nodeNames.length > 0) {
             traversal = traversal.has("name", P.within(nodeNames));
-        } 
+        }
 
         return traversal.path();
     }
@@ -159,183 +165,194 @@ public class KubeHoundTraversalSourceDsl extends GraphTraversalSource {
      */
     public GraphTraversal<Vertex, Vertex> endpoints() {
         GraphTraversal traversal = this.clone().V();
-    
-        traversal = traversal.hasLabel("Endpoint");
+
+        traversal = traversal.has("class", "Endpoint");
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "Endpoint" label and optionally allows filtering of those
+     * Starts a traversal that finds all vertices with a "Endpoint" label and
+     * optionally allows filtering of those
      * vertices on the "exposure" property.
      *
      * @param exposure EndpointExposure enum value to filter on
      */
     public GraphTraversal<Vertex, Vertex> endpoints(EndpointExposure exposure) {
         if (exposure.ordinal() > EndpointExposure.Max.ordinal()) {
-            throw new IllegalArgumentException(String.format("invalid exposure value (must be <= %d)", EndpointExposure.Max.ordinal()));
+            throw new IllegalArgumentException(
+                    String.format("invalid exposure value (must be <= %d)", EndpointExposure.Max.ordinal()));
         }
 
         if (exposure.ordinal() < EndpointExposure.None.ordinal()) {
-            throw new IllegalArgumentException(String.format("invalid exposure value (must be >= %d)", EndpointExposure.None.ordinal()));
+            throw new IllegalArgumentException(
+                    String.format("invalid exposure value (must be >= %d)", EndpointExposure.None.ordinal()));
         }
 
         GraphTraversal traversal = this.clone().V();
-        
+
         traversal = traversal
-            .hasLabel("Endpoint")
-            .has("exposure", P.gte(exposure.ordinal()));
+                .has("class", "Endpoint")
+                .has("exposure", P.gte(exposure.ordinal()));
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "Endpoint" label exposed OUTSIDE the cluster as a service 
+     * Starts a traversal that finds all vertices with a "Endpoint" label exposed
+     * OUTSIDE the cluster as a service
      * and optionally allows filtering of those vertices on the "portName" property.
      *
      * @param portNames list of port names to filter on
      */
     public GraphTraversal<Vertex, Vertex> services(String... portNames) {
         GraphTraversal traversal = this.clone().V();
-        
+
         traversal = traversal
-            .hasLabel("Endpoint")
-            .has("exposure", P.gte(EndpointExposure.External.ordinal()));
+                .has("class", "Endpoint")
+                .has("exposure", P.gte(EndpointExposure.External.ordinal()));
 
         if (portNames.length > 0) {
             traversal = traversal.has("portName", P.within(portNames));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "Volume" label and optionally allows filtering of those
+     * Starts a traversal that finds all vertices with a "Volume" label and
+     * optionally allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of volume names to filter on
      */
     public GraphTraversal<Vertex, Vertex> volumes(String... names) {
         GraphTraversal traversal = this.clone().V();
-        
-        traversal = traversal.hasLabel("Volume");
+
+        traversal = traversal.has("class", "Volume");
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices representing volume host mounts and optionally allows filtering of those
+     * Starts a traversal that finds all vertices representing volume host mounts
+     * and optionally allows filtering of those
      * vertices on the "sourcePath" property.
      *
      * @param sourcePaths list of host source paths to filter on
      */
     public GraphTraversal<Vertex, Vertex> hostMounts(String... sourcePaths) {
         GraphTraversal traversal = this.clone().V();
-        
+
         traversal = traversal
-            .hasLabel("Volume")
-            .has("type", "HostPath");
+                .has("class", "Volume")
+                .has("type", "HostPath");
 
         if (sourcePaths.length > 0) {
             traversal = traversal.has("sourcePath", P.within(sourcePaths));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "Identity" label and optionally allows filtering of those
+     * Starts a traversal that finds all vertices with a "Identity" label and
+     * optionally allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of identity names to filter on
      */
     public GraphTraversal<Vertex, Vertex> identities(String... names) {
         GraphTraversal traversal = this.clone().V();
-        
-        traversal = traversal.hasLabel("Identity");
+
+        traversal = traversal.has("class", "Identity");
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices representing service accounts and optionally allows filtering of those
+     * Starts a traversal that finds all vertices representing service accounts and
+     * optionally allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of service account names to filter on
      */
     public GraphTraversal<Vertex, Vertex> sas(String... names) {
         GraphTraversal traversal = this.clone().V();
-        
+
         traversal = traversal
-            .hasLabel("Identity")
-            .has("type", "ServiceAccount");
+                .has("class", "Identity")
+                .has("type", "ServiceAccount");
 
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices representing users and optionally allows filtering of those
+     * Starts a traversal that finds all vertices representing users and optionally
+     * allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of user names to filter on
      */
     public GraphTraversal<Vertex, Vertex> users(String... names) {
         GraphTraversal traversal = this.clone().V();
-        
+
         traversal = traversal
-            .hasLabel("Identity")
-            .has("type", "User");
+                .has("class", "Identity")
+                .has("type", "User");
 
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices representing groups and optionally allows filtering of those
+     * Starts a traversal that finds all vertices representing groups and optionally
+     * allows filtering of those
      * vertices on the "name" property.
      *
      * @param names list of groups names to filter on
      */
     public GraphTraversal<Vertex, Vertex> groups(String... names) {
         GraphTraversal traversal = this.clone().V();
-         
+
         traversal = traversal
-            .hasLabel("Identity")
-            .has("type", "Group");
+                .has("class", "Identity")
+                .has("type", "Group");
 
         if (names.length > 0) {
             traversal = traversal.has("name", P.within(names));
-        } 
+        }
 
         return traversal;
     }
 
     /**
-     * Starts a traversal that finds all vertices with a "PermissionSet" label and optionally allows filtering of those
+     * Starts a traversal that finds all vertices with a "PermissionSet" label and
+     * optionally allows filtering of those
      * vertices on the "role" property.
      *
      * @param roles list of underlying role names to filter on
      */
     public GraphTraversal<Vertex, Vertex> permissions(String... roles) {
         GraphTraversal traversal = this.clone().V();
-        
-        traversal = traversal.hasLabel("PermissionSet");
+
+        traversal = traversal.has("class", "PermissionSet");
         if (roles.length > 0) {
             traversal = traversal.has("role", P.within(roles));
-        } 
+        }
 
         return traversal;
     }

--- a/docs/queries/dsl.md
+++ b/docs/queries/dsl.md
@@ -17,21 +17,21 @@ _DSL definition code available [here](https://github.com/DataDog/KubeHound/blob/
 
 ### Retrieve cluster data
 
-| Method                      | Gremlin equivalent                                    |
-| --------------------------- | ----------------------------------------------------- |
-| `.cluster([string...])`     | `.hasLabel("Cluster")`                                |
-| `.containers([string...])`  | `.hasLabel("Container")`                              |
-| `.endpoints([int])`         | `.hasLabel("Endpoint")`                               |
-| `.groups([string...])`      | `.hasLabel("Group")`                                  |
-| `.hostMounts([string...])`  | `.hasLabel("Volume").has("type", "HostPath")`         |
-| `.nodes([string...])`       | `.hasLabel("Node")`                                   |
-| `.permissions([string...])` | `.hasLabel("PermissionSet")`                          |
-| `.pods([string...])`        | `.hasLabel("Pod")`                                    |
-| `.run([string...])`         | `.has("runID", P.within(ids)`                         |
-| `.sas([string...])`         | `.hasLabel("Identity").has("type", "ServiceAccount")` |
-| `.services([string...])`    | `.hasLabel("Endpoint").has("exposure", EXTERNAL)`     |
-| `.users([string...])`       | `.hasLabel("Identity").has("type", "User")`           |
-| `.volumes([string...])`     | `.hasLabel("Volume")`                                 |
+| Method                      | Gremlin equivalent                                       |
+| --------------------------- | -------------------------------------------------------- |
+| `.cluster([string...])`     | `.has("class","Cluster")`                                |
+| `.containers([string...])`  | `.has("class","Container")`                              |
+| `.endpoints([int])`         | `.has("class","Endpoint")`                               |
+| `.groups([string...])`      | `.has("class","Group")`                                  |
+| `.hostMounts([string...])`  | `.has("class","Volume").has("type", "HostPath")`         |
+| `.nodes([string...])`       | `.has("class","Node")`                                   |
+| `.permissions([string...])` | `.has("class","PermissionSet")`                          |
+| `.pods([string...])`        | `.has("class","Pod")`                                    |
+| `.run([string...])`         | `.has("runID", P.within(ids)`                            |
+| `.sas([string...])`         | `.has("class","Identity").has("type", "ServiceAccount")` |
+| `.services([string...])`    | `.has("class","Endpoint").has("exposure", EXTERNAL)`     |
+| `.users([string...])`       | `.has("class","Identity").has("type", "User")`           |
+| `.volumes([string...])`     | `.has("class","Volume")`                                 |
 
 ### Retrieving attack oriented data
 

--- a/docs/queries/gremlin.md
+++ b/docs/queries/gremlin.md
@@ -1,92 +1,92 @@
-# Queries 
+# Queries
 
 You can query KubeHound data stored in the JanusGraph database by using the [Gremlin query language](https://docs.janusgraph.org/getting-started/gremlin/).
 
 ## Basic queries
 
-``` java title="Count the number of pods in the cluster"
-g.V().hasLabel("Pod").count()
+```java title="Count the number of pods in the cluster"
+g.V().has("class","Pod").count()
 ```
 
-``` java title="View all possible container escapes in the cluster"
-g.V().hasLabel("Container").outE().inV().hasLabel("Node").path()
+```java title="View all possible container escapes in the cluster"
+g.V().has("class","Container").outE().inV().has("class","Node").path()
 ```
 
-``` java title="List the names of all possible attacks in the cluster"
+```java title="List the names of all possible attacks in the cluster"
 g.E().groupCount().by(label)
 ```
 
-``` java title="View all the mounted host path volumes in the cluster"
-g.V().hasLabel("Volume").has("type", "HostPath").groupCount().by("sourcePath")
+```java title="View all the mounted host path volumes in the cluster"
+g.V().has("class","Volume").has("type", "HostPath").groupCount().by("sourcePath")
 ```
 
-``` java title="View host path mounts that can be exploited to escape to a node"
-g.E().hasLabel("EXPLOIT_HOST_READ", "EXPLOIT_HOST_WRITE").outV().groupCount().by("sourcePath")
+```java title="View host path mounts that can be exploited to escape to a node"
+g.E().has("class","EXPLOIT_HOST_READ", "EXPLOIT_HOST_WRITE").outV().groupCount().by("sourcePath")
 ```
 
-``` java title="View all service endpoints by service name in the cluster"
+```java title="View all service endpoints by service name in the cluster"
 // Leveraging the "EndpointExposureType" enum value to filter only on services
 // c.f. https://github.com/DataDog/KubeHound/blob/main/pkg/kubehound/models/shared/constants.go
-g.V().hasLabel("Endpoint").has("exposure", 3).groupCount().by("serviceEndpoint")
+g.V().has("class","Endpoint").has("exposure", 3).groupCount().by("serviceEndpoint")
 ```
 
 ## Basic attack paths
 
-``` java title="All paths between an endpoint and a node"
-g.V().hasLabel("Endpoint").repeat(out().simplePath()).until(hasLabel("Node")).path()
+```java title="All paths between an endpoint and a node"
+g.V().has("class","Endpoint").repeat(out().simplePath()).until(has("class","Node")).path()
 ```
 
-``` java title="All paths (up to 5 hops) between a container and a node"
-g.V().hasLabel("Container").repeat(out().simplePath()).until(hasLabel("Node").or().loops().is(5)).hasLabel("Node").path()
+```java title="All paths (up to 5 hops) between a container and a node"
+g.V().has("class","Container").repeat(out().simplePath()).until(has("class","Node").or().loops().is(5)).has("class","Node").path()
 ```
 
-``` java title="All attack paths (up to 6 hops) from any compomised identity (e.g. service account) to a critical asset"
-g.V().hasLabel("Identity").repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().limit(5)
+```java title="All attack paths (up to 6 hops) from any compomised identity (e.g. service account) to a critical asset"
+g.V().has("class","Identity").repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().limit(5)
 ```
 
-## Attack paths from compromised assets 
+## Attack paths from compromised assets
 
 ### Containers
 
-``` java title="Attack paths (up to 10 hops) from a known breached container to any critical asset"
-g.V().hasLabel("Container").has("name", "nsenter-pod").repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).path()
+```java title="Attack paths (up to 10 hops) from a known breached container to any critical asset"
+g.V().has("class","Container").has("name", "nsenter-pod").repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).path()
 ```
 
-``` java title="Attack paths (up to 10 hops) from a known backdoored container image to any critical asset"
-g.V().hasLabel("Container").has("image", TextP.containing("malicious-image")).repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).path()
+```java title="Attack paths (up to 10 hops) from a known backdoored container image to any critical asset"
+g.V().has("class","Container").has("image", TextP.containing("malicious-image")).repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).path()
 ```
 
 ### Credentials
 
-``` java title="Attack paths (up to 10 hops) from a known breached identity to a critical asset"
-g.V().hasLabel("Identity").has("name", "compromised-sa").repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).path()
+```java title="Attack paths (up to 10 hops) from a known breached identity to a critical asset"
+g.V().has("class","Identity").has("name", "compromised-sa").repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).path()
 ```
 
 ### Endpoints
 
-``` java title="Attack paths (up to 6 hops) from any endpoint to a critical asset:"
-g.V().hasLabel("Endpoint").repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().limit(5)
+```java title="Attack paths (up to 6 hops) from any endpoint to a critical asset:"
+g.V().has("class","Endpoint").repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().limit(5)
 ```
 
-``` java title="Attack paths (up to 10 hops) from a known risky endpoint (e.g JMX) to a critical asset"
-g.V().hasLabel("Endpoint").has("portName", "jmx").repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().limit(5)
+```java title="Attack paths (up to 10 hops) from a known risky endpoint (e.g JMX) to a critical asset"
+g.V().has("class","Endpoint").has("portName", "jmx").repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().limit(5)
 ```
 
 ## Risk assessment
 
-``` java title="What is the shortest exploitable path between an exposed service and a critical asset?"
-g.V().hasLabel("Endpoint").has("exposure", gte(3)).repeat(out().simplePath()).until(has("critical", true).or().loops().is(7)).has("critical", true).path().count(local).min()
+```java title="What is the shortest exploitable path between an exposed service and a critical asset?"
+g.V().has("class","Endpoint").has("exposure", gte(3)).repeat(out().simplePath()).until(has("critical", true).or().loops().is(7)).has("critical", true).path().count(local).min()
 ```
 
-``` java title="What percentage of external facing services have an exploitable path to a critical asset?"
+```java title="What percentage of external facing services have an exploitable path to a critical asset?"
 // Leveraging the "EndpointExposureType" enum value to filter only on services
 // c.f. https://github.com/DataDog/KubeHound/blob/main/pkg/kubehound/models/shared/constants.go
 
 // Base case
-g.V().hasLabel("Endpoint").has("exposure", gte(3)).count()
+g.V().has("class","Endpoint").has("exposure", gte(3)).count()
 
 // Has a critical path
-g.V().hasLabel("Endpoint").has("exposure", gte(3)).where(repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).limit(1)).count()
+g.V().has("class","Endpoint").has("exposure", gte(3)).where(repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).limit(1)).count()
 ```
 
 ## CVE impact assessment
@@ -96,30 +96,30 @@ You can also use KubeHound to determine if workloads in your cluster may be vuln
 First, evaluate if a known vulnerable image is running in the cluster:
 
 ```java
-g.V().hasLabel("Container").has("image", TextP.containing("elasticsearch")).groupCount().by("image")
+g.V().has("class","Container").has("image", TextP.containing("elasticsearch")).groupCount().by("image")
 ```
 
 Then, check any exposed services that could be affected and have a path to a critical asset. This helps prioritizing patching and remediation.
 
 ```java
-g.V().hasLabel("Container").has("image", "dockerhub.com/elasticsearch:7.1.4").where(inE("ENDPOINT_EXPLOIT").outV().has("exposure", gte(3))).where(repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).limit(1))
+g.V().has("class","Container").has("image", "dockerhub.com/elasticsearch:7.1.4").where(inE("ENDPOINT_EXPLOIT").outV().has("exposure", gte(3))).where(repeat(out().simplePath()).until(has("critical", true).or().loops().is(10)).has("critical", true).limit(1))
 ```
 
 ## Assessing the value of implementing new security controls
 
 To verify concrete impact, this can be achieved by comparing the difference in the key risk metrics above, before and after the control change. To simulate the impact of introducing a control (e.g to evaluate ROI), we can add conditions to our path queries. For example if we wanted to evaluate the impact of adding a gatekeeper rule that would deny the use of `hostPID` we can use the following:
 
-``` java title="What percentage level of attack path reduction was achieved by the introduction of a control?"
+```java title="What percentage level of attack path reduction was achieved by the introduction of a control?"
 // Calculate the base case
-g.V().hasLabel("Endpoint").has("exposure", gte(3)).repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().count()
+g.V().has("class","Endpoint").has("exposure", gte(3)).repeat(out().simplePath()).until(has("critical", true).or().loops().is(6)).has("critical", true).path().count()
 
 // Calculate the impact of preventing CE_NSENTER attack
-g.V().hasLabel("Endpoint").has("exposure", gte(3)).repeat(outE().not(hasLabel("CE_NSENTER")).inV().simplePath()).emit().until(has("critical", true).or().loops().is(6)).has("critical", true).path().count()
+g.V().has("class","Endpoint").has("exposure", gte(3)).repeat(outE().not(has("class","CE_NSENTER")).inV().simplePath()).emit().until(has("critical", true).or().loops().is(6)).has("critical", true).path().count()
 ```
 
-``` java title="What type of control would cut off the largest number of attack paths to a specific asset in the cluster?"
+```java title="What type of control would cut off the largest number of attack paths to a specific asset in the cluster?"
 // We count the number of instances of unique attack paths using
-g.V().hasLabel("Container").repeat(outE().inV().simplePath()).emit()
+g.V().has("class","Container").repeat(outE().inV().simplePath()).emit()
 .until(has("critical", true).or().loops().is(6)).has("critical", true)
 .path().by(label).groupCount().order(local).by(select(values), desc)
 
@@ -136,15 +136,15 @@ g.V().hasLabel("Container").repeat(outE().inV().simplePath()).emit()
 
 ## Threat modelling
 
-``` java title="All unique attack paths by labels to a specific asset (here, the cluster-admin role)"
-g.V().hasLabel("Container", "Identity")
+```java title="All unique attack paths by labels to a specific asset (here, the cluster-admin role)"
+g.V().has("class","Container", "Identity")
 .repeat(out().simplePath())
 .until(has("name", "cluster-admin").or().loops().is(5))
-.has("name", "cluster-admin").hasLabel("Role").path().as("p").by(label).dedup().select("p").path()
+.has("name", "cluster-admin").has("class","Role").path().as("p").by(label).dedup().select("p").path()
 ```
 
-``` java title="All unique attack paths by labels to a any critical asset"
-g.V().hasLabel("Container", "Identity")
+```java title="All unique attack paths by labels to a any critical asset"
+g.V().has("class","Container", "Identity")
 .repeat(out().simplePath())
 .until(has("critical", true).or().loops().is(5))
 .has("critical", true).path().as("p").by(label).dedup().select("p").path()
@@ -160,10 +160,11 @@ To get started with Gremlin, have a look at the following tutorials:
 For large clusters it is recommended to add a `limit()` step to **all** queries where the graph output will be examined in the UI to prevent overloading it. An example looking for attack paths possible from a sample of 5 containers would look like:
 
 ```go
-g.V().hasLabel("Container").limit(5).outE()
+g.V().has("class","Container").limit(5).outE()
 ```
 
 Additional tips:
+
 - For queries to be displayed in the UI, try to limit the output to 1000 elements or less
 - Enable `large cluster optimizations` via configuration file if queries are returning too slowly
-- Try to filter the initial element of queries by namespace/service/app to avoid generating too many results, for instance `g.V().hasLabel("Container").has("namespace", "your-namespace")`
+- Try to filter the initial element of queries by namespace/service/app to avoid generating too many results, for instance `g.V().has("class","Container").has("namespace", "your-namespace")`

--- a/pkg/kubehound/graph/edge/escape_var_log_symlink.go
+++ b/pkg/kubehound/graph/edge/escape_var_log_symlink.go
@@ -60,13 +60,13 @@ func (e *EscapeVarLogSymlink) Traversal() types.EdgeTraversal {
 	return func(source *gremlin.GraphTraversalSource, inserts []any) *gremlin.GraphTraversal {
 		g := source.GetGraphTraversal()
 		// reduce the graph to only these permission sets
-		g.V(inserts...).HasLabel("PermissionSet").
+		g.V(inserts...).Has("class", "PermissionSet").
 			// get identity vertices
 			InE("PERMISSION_DISCOVER").OutV().
 			// get container vertices
 			InE("IDENTITY_ASSUME").OutV().
 			// save container vertices as "c" so we can link to it to the node via CE_VAR_LOG_SYMLINK
-			HasLabel("Container").As("c").
+			Has("class", "Container").As("c").
 			// Get all the volumes
 			OutE("VOLUME_DISCOVER").InV().
 			Has("type", shared.VolumeTypeHost).
@@ -74,7 +74,7 @@ func (e *EscapeVarLogSymlink) Traversal() types.EdgeTraversal {
 			Has("sourcePath", P.Within("/", "/var", "/var/log")).
 			// get the node related to that volume mount
 			InE("VOLUME_ACCESS").OutV().
-			HasLabel("Node").As("n").
+			Has("class", "Node").As("n").
 			AddE("CE_VAR_LOG_SYMLINK").From("c").To("n").
 			Barrier().Limit(0)
 

--- a/scripts/dashboard-demo/main.py
+++ b/scripts/dashboard-demo/main.py
@@ -72,11 +72,11 @@ class EndpointKPI(KPI):
     KH_QUERY_EXTERNAL_COUNTS = "kh.endpoints().count()"
     KH_QUERY_DETAILS= 'kh.endpoints().criticalPaths().limit(local,1).dedup().valueMap("serviceEndpoint","port", "namespace")'
     KH_QUERY_EXTERNAL_CRITICAL_PATH = '''kh.V().
-    hasLabel("Endpoint").
+    has("class","Endpoint").
     count().
     aggregate("t").
     V().
-    hasLabel("Endpoint").
+    has("class","Endpoint").
     hasCriticalPath().
     count().
     as("e").
@@ -95,12 +95,12 @@ class IdentitiesKPI(KPI):
     KH_QUERY_EXTERNAL_COUNTS = "kh.identities().count()"
     KH_QUERY_DETAILS= 'kh.identities().criticalPaths().limit(local,1).dedup().valueMap("name","type","namespace")'
     KH_QUERY_EXTERNAL_CRITICAL_PATH = '''kh.V().
-    hasLabel("Identity").
+    has("class","Identity").
     has("critical", false).
     count().
     aggregate("t").
     V().
-    hasLabel("Identity").
+    has("class","Identity").
     has("critical", false).
     hasCriticalPath().
     count().
@@ -121,11 +121,11 @@ class ContainersKPI(KPI):
     KH_QUERY_EXTERNAL_COUNTS = "kh.containers().count()"
     KH_QUERY_DETAILS= 'kh.containers().criticalPaths().limit(local,1).dedup().valueMap("name","image","app","namespace")'
     KH_QUERY_EXTERNAL_CRITICAL_PATH = '''kh.V().
-    hasLabel("Container").
+    has("class","Container").
     count().
     aggregate("t").
     V().
-    hasLabel("Container").
+    has("class","Container").
     hasCriticalPath().
     count().
     as("e").
@@ -146,11 +146,11 @@ class VolumesKPI(KPI):
     KH_QUERY_DETAILS= 'kh.volumes().criticalPaths().limit(local,1).dedup().valueMap("name","sourcePath", "namespace")'
     KH_QUERY_DETAILS_KEYS = ["name", "sourcePath"]
     KH_QUERY_EXTERNAL_CRITICAL_PATH = '''kh.V().
-    hasLabel("Volume").
+    has("class","Volume").
     count().
     aggregate("t").
     V().
-    hasLabel("Volume").
+    has("class","Volume").
     hasCriticalPath().
     count().
     as("e").

--- a/test/system/graph_edge_test.go
+++ b/test/system/graph_edge_test.go
@@ -142,7 +142,7 @@ func (suite *EdgeTestSuite) TestEdge_CE_UMH_CORE_PATTERN() {
 func (suite *EdgeTestSuite) TestEdge_CONTAINER_ATTACH() {
 	// Every container should have a CONTAINER_ATTACH incoming from a pod
 	rawCount, err := suite.g.V().
-		HasLabel("Container").
+		Has("class", "Container").
 		Count().Next()
 
 	suite.NoError(err)
@@ -151,9 +151,9 @@ func (suite *EdgeTestSuite) TestEdge_CONTAINER_ATTACH() {
 	suite.NotEqual(containerCount, 0)
 
 	rawCount, err = suite.g.V().
-		HasLabel("Pod").
+		Has("class", "Pod").
 		OutE().HasLabel("CONTAINER_ATTACH").
-		InV().HasLabel("Container").
+		InV().Has("class", "Container").
 		Dedup().
 		Path().
 		Count().Next()
@@ -177,9 +177,9 @@ func (suite *EdgeTestSuite) TestEdge_IDENTITY_ASSUME_Container() {
 	// tokenlist-sa     0         7h39m
 
 	results, err := suite.g.V().
-		HasLabel("Container").
+		Has("class", "Container").
 		OutE().HasLabel("IDENTITY_ASSUME").
-		InV().HasLabel("Identity").
+		InV().Has("class", "Identity").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -212,9 +212,9 @@ func (suite *EdgeTestSuite) TestEdge_IDENTITY_ASSUME_Container() {
 
 func (suite *EdgeTestSuite) TestEdge_IDENTITY_ASSUME_Node() {
 	results, err := suite.g.V().
-		HasLabel("Node").
+		Has("class", "Node").
 		OutE().HasLabel("IDENTITY_ASSUME").
-		InV().HasLabel("Identity").
+		InV().Has("class", "Identity").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -243,9 +243,9 @@ func (suite *EdgeTestSuite) TestEdge_POD_ATTACH() {
 	suite.NotEqual(podCount, 0)
 
 	rawCount, err = suite.g.V().
-		HasLabel("Node").
+		Has("class", "Node").
 		OutE().HasLabel("POD_ATTACH").
-		InV().HasLabel("Pod").
+		InV().Has("class", "Pod").
 		Dedup().
 		Path().
 		Count().Next()
@@ -260,10 +260,10 @@ func (suite *EdgeTestSuite) TestEdge_POD_PATCH() {
 	// We have one bespoke container running with pod/patch permissions which should reach all nodes
 	// since they are not namespaced
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("namespace", "default").
 		OutE().HasLabel("POD_PATCH").
-		InV().HasLabel("Pod").
+		InV().Has("class", "Pod").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -309,10 +309,10 @@ func (suite *EdgeTestSuite) TestEdge_POD_CREATE() {
 	// We have one bespoke container running with pod/create permissions which should reach all nodes
 	// since they are not namespaced
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("namespace", "default").
 		OutE().HasLabel("POD_CREATE").
-		InV().HasLabel("Node").
+		InV().Has("class", "Node").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -332,10 +332,10 @@ func (suite *EdgeTestSuite) TestEdge_POD_CREATE() {
 func (suite *EdgeTestSuite) TestEdge_POD_EXEC() {
 	// We have one bespoke container running with pod/exec permissions which should reach all pods in the namespace
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("namespace", "default").
 		OutE().HasLabel("POD_EXEC").
-		InV().HasLabel("Pod").
+		InV().Has("class", "Pod").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -391,10 +391,10 @@ func (suite *EdgeTestSuite) TestEdge_PERMISSION_DISCOVER() {
 	// tokenget-sa      0         7h39m
 	// tokenlist-sa     0         7h39m
 	results, err := suite.g.V().
-		HasLabel("Identity").
+		Has("class", "Identity").
 		Has("namespace", "default").
 		OutE().HasLabel("PERMISSION_DISCOVER").
-		InV().HasLabel("PermissionSet").
+		InV().Has("class", "PermissionSet").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -429,7 +429,7 @@ func (suite *EdgeTestSuite) TestEdge_PERMISSION_DISCOVER() {
 func (suite *EdgeTestSuite) TestEdge_VOLUME_ACCESS() {
 	// Every volume should have a VOLUME_ACCESS incoming from a node
 	rawCount, err := suite.g.V().
-		HasLabel("Volume").
+		Has("class", "Volume").
 		Count().Next()
 
 	suite.NoError(err)
@@ -438,9 +438,9 @@ func (suite *EdgeTestSuite) TestEdge_VOLUME_ACCESS() {
 	suite.NotEqual(volumeCount, 0)
 
 	rawCount, err = suite.g.V().
-		HasLabel("Node").
+		Has("class", "Node").
 		OutE().HasLabel("VOLUME_ACCESS").
-		InV().HasLabel("Volume").
+		InV().Has("class", "Volume").
 		Dedup().
 		Path().
 		Count().Next()
@@ -454,7 +454,7 @@ func (suite *EdgeTestSuite) TestEdge_VOLUME_ACCESS() {
 func (suite *EdgeTestSuite) TestEdge_VOLUME_DISCOVER() {
 	// Every volume should have a VOLUME_DISCOVER incoming from a container
 	rawCount, err := suite.g.V().
-		HasLabel("Volume").
+		Has("class", "Volume").
 		Count().Next()
 
 	suite.NoError(err)
@@ -463,9 +463,9 @@ func (suite *EdgeTestSuite) TestEdge_VOLUME_DISCOVER() {
 	suite.NotEqual(volumeCount, 0)
 
 	rawCount, err = suite.g.V().
-		HasLabel("Container").
+		Has("class", "Container").
 		OutE().HasLabel("VOLUME_DISCOVER").
-		InV().HasLabel("Volume").
+		InV().Has("class", "Volume").
 		Dedup().
 		Path().
 		Count().Next()
@@ -478,10 +478,10 @@ func (suite *EdgeTestSuite) TestEdge_VOLUME_DISCOVER() {
 
 func (suite *EdgeTestSuite) TestEdge_TOKEN_BRUTEFORCE() {
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("namespace", "default").
 		OutE().HasLabel("TOKEN_BRUTEFORCE").
-		InV().HasLabel("Identity").
+		InV().Has("class", "Identity").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -514,10 +514,10 @@ func (suite *EdgeTestSuite) TestEdge_TOKEN_BRUTEFORCE() {
 
 func (suite *EdgeTestSuite) TestEdge_TOKEN_LIST() {
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("namespace", "default").
 		OutE().HasLabel("TOKEN_LIST").
-		InV().HasLabel("Identity").
+		InV().Has("class", "Identity").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -552,11 +552,11 @@ func (suite *EdgeTestSuite) TestEdge_TOKEN_STEAL() {
 	// Every pod in our test cluster should have projected volume holding a token. BUT we only
 	// save those with a non-default service account token as shown below.
 	results, err := suite.g.V().
-		HasLabel("Volume").
+		Has("class", "Volume").
 		OutE().
 		HasLabel("TOKEN_STEAL").
 		InV().
-		HasLabel("Identity").
+		Has("class", "Identity").
 		Has("namespace", "default").
 		Values("name").
 		ToList()
@@ -589,11 +589,11 @@ func (suite *EdgeTestSuite) TestEdge_TOKEN_STEAL() {
 
 func (suite *EdgeTestSuite) TestEdge_EXPLOIT_HOST_READ() {
 	results, err := suite.g.V().
-		HasLabel("Container").
+		Has("class", "Container").
 		OutE().HasLabel("VOLUME_DISCOVER").
-		InV().HasLabel("Volume").
+		InV().Has("class", "Volume").
 		Where(__.OutE().HasLabel("EXPLOIT_HOST_READ").
-			InV().HasLabel("Node")).
+			InV().Has("class", "Node")).
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -610,11 +610,11 @@ func (suite *EdgeTestSuite) TestEdge_EXPLOIT_HOST_READ() {
 
 func (suite *EdgeTestSuite) TestEdge_EXPLOIT_HOST_WRITE() {
 	results, err := suite.g.V().
-		HasLabel("Container").
+		Has("class", "Container").
 		OutE().HasLabel("VOLUME_DISCOVER").
-		InV().HasLabel("Volume").
+		InV().Has("class", "Volume").
 		Where(__.OutE().HasLabel("EXPLOIT_HOST_WRITE").
-			InV().HasLabel("Node")).
+			InV().Has("class", "Node")).
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -633,10 +633,10 @@ func (suite *EdgeTestSuite) TestEdge_EXPLOIT_HOST_TRAVERSE() {
 	for _, c := range []string{"host-read-exploit-pod", "host-write-exploit-pod"} {
 		// Find the containers on the same node as our vulnerable pod and map to their service accounts
 		results, err := suite.g.V().
-			HasLabel("Container").
+			Has("class", "Container").
 			Has("name", c).
 			Values("node").As("n").
-			V().HasLabel("Container").
+			V().Has("class", "Container").
 			Has("node", __.Where(P.Eq("n"))).
 			OutE("IDENTITY_ASSUME").
 			InV().
@@ -649,14 +649,14 @@ func (suite *EdgeTestSuite) TestEdge_EXPLOIT_HOST_TRAVERSE() {
 
 		// Now find the identities our vulnerable pod can reach via doing a traverse to the projected token volume
 		results, err = suite.g.V().
-			HasLabel("Container").
+			Has("class", "Container").
 			Has("name", c).
 			OutE().HasLabel("VOLUME_DISCOVER").
-			InV().HasLabel("Volume").
+			InV().Has("class", "Volume").
 			OutE().HasLabel("EXPLOIT_HOST_TRAVERSE").
-			InV().HasLabel("Volume").
+			InV().Has("class", "Volume").
 			OutE().HasLabel("TOKEN_STEAL").
-			InV().HasLabel("Identity").
+			InV().Has("class", "Identity").
 			Values("name").
 			ToList()
 
@@ -671,12 +671,12 @@ func (suite *EdgeTestSuite) TestEdge_EXPLOIT_HOST_TRAVERSE() {
 
 func (suite *EdgeTestSuite) TestEdge_ENDPOINT_EXPLOIT_ContainerPort() {
 	results, err := suite.g.V().
-		HasLabel("Endpoint").
+		Has("class", "Endpoint").
 		Where(
 			__.Has("exposure", P.Eq(int(shared.EndpointExposureClusterIP))).
 				OutE("ENDPOINT_EXPLOIT").
 				InV().
-				HasLabel("Container")).
+				Has("class", "Container")).
 		Values("serviceEndpoint").
 		ToList()
 
@@ -693,12 +693,12 @@ func (suite *EdgeTestSuite) TestEdge_ENDPOINT_EXPLOIT_ContainerPort() {
 
 func (suite *EdgeTestSuite) TestEdge_ENDPOINT_EXPLOIT_NodePort() {
 	results, err := suite.g.V().
-		HasLabel("Endpoint").
+		Has("class", "Endpoint").
 		Where(
 			__.Has("exposure", P.Eq(int(shared.EndpointExposureNodeIP))).
 				OutE("ENDPOINT_EXPLOIT").
 				InV().
-				HasLabel("Container")).
+				Has("class", "Container")).
 		Values("serviceEndpoint").
 		ToList()
 
@@ -715,12 +715,12 @@ func (suite *EdgeTestSuite) TestEdge_ENDPOINT_EXPLOIT_NodePort() {
 
 func (suite *EdgeTestSuite) TestEdge_ENDPOINT_EXPLOIT_External() {
 	results, err := suite.g.V().
-		HasLabel("Endpoint").
+		Has("class", "Endpoint").
 		Where(
 			__.Has("exposure", P.Eq(int(shared.EndpointExposureExternal))).
 				OutE("ENDPOINT_EXPLOIT").
 				InV().
-				HasLabel("Container")).
+				Has("class", "Container")).
 		Values("serviceEndpoint").
 		ToList()
 
@@ -737,9 +737,9 @@ func (suite *EdgeTestSuite) TestEdge_ENDPOINT_EXPLOIT_External() {
 
 func (suite *EdgeTestSuite) TestEdge_SHARE_PS_NAMESPACE() {
 	results, err := suite.g.V().
-		HasLabel("Container").
+		Has("class", "Container").
 		OutE().HasLabel("SHARE_PS_NAMESPACE").
-		InV().HasLabel("Container").
+		InV().Has("class", "Container").
 		Path().
 		By(__.ValueMap("name")).
 		ToList()
@@ -767,10 +767,10 @@ func (suite *EdgeTestSuite) TestEdge_SHARE_PS_NAMESPACE() {
 // Case 1 (cf docs)
 func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_1() {
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("isNamespaced", false).
 		OutE().HasLabel("ROLE_BIND").
-		InV().HasLabel("PermissionSet").
+		InV().Has("class", "PermissionSet").
 		Has("isNamespaced", false).
 		// Scoping only to the roles related to the attacks to avoid dependency on the Kind Cluster default roles
 		Has("name", gremlingo.TextP.StartingWith("rolebind")).
@@ -798,10 +798,10 @@ func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_1() {
 // Case 2 (cf docs)
 func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_2() {
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("isNamespaced", false).
 		OutE().HasLabel("ROLE_BIND").
-		InV().HasLabel("PermissionSet").
+		InV().Has("class", "PermissionSet").
 		Has("isNamespaced", false).
 		// Scoping only to the roles related to the attacks to avoid dependency on the Kind Cluster default roles
 		Has("name", gremlingo.TextP.StartingWith("rolebind")).
@@ -829,10 +829,10 @@ func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_2() {
 // Case 3 (cf docs)
 func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_3() {
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("isNamespaced", true).
 		OutE().HasLabel("ROLE_BIND").
-		InV().HasLabel("PermissionSet").
+		InV().Has("class", "PermissionSet").
 		Has("isNamespaced", true).
 		// Scoping only to the roles related to the attacks to avoid dependency on the Kind Cluster default roles
 		Has("name", gremlingo.TextP.StartingWith("rolebind-")).
@@ -896,10 +896,10 @@ func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_3() {
 // Case 4 (cf docs)
 func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_4() {
 	results, err := suite.g.V().
-		HasLabel("PermissionSet").
+		Has("class", "PermissionSet").
 		Has("isNamespaced", true).
 		OutE().HasLabel("ROLE_BIND").
-		InV().HasLabel("PermissionSet").
+		InV().Has("class", "PermissionSet").
 		Has("isNamespaced", false).
 		// Scoping only to the roles related to the attacks to avoid dependency on the Kind Cluster default roles
 		Has("name", gremlingo.TextP.StartingWith("rolebind")).
@@ -919,7 +919,7 @@ func (suite *EdgeTestSuite) TestEdge_ROLE_BIND_CASE_4() {
 func (suite *EdgeTestSuite) Test_NoEdgeCase() {
 	// The control pod has no interesting properties and therefore should have NO outgoing edges
 	results, err := suite.g.V().
-		HasLabel("Container").
+		Has("class", "Container").
 		Has("name", "control-pod").
 		Out().
 		ToList()

--- a/test/system/graph_vertex_test.go
+++ b/test/system/graph_vertex_test.go
@@ -106,7 +106,7 @@ func (suite *VertexTestSuite) resultsToStringArray(results []*gremlingo.Result) 
 }
 
 func (suite *VertexTestSuite) TestVertexContainer() {
-	results, err := suite.g.V().HasLabel(vertex.ContainerLabel).ElementMap().ToList()
+	results, err := suite.g.V().Has("class", vertex.ContainerLabel).ElementMap().ToList()
 	suite.NoError(err)
 
 	suite.Equal(len(expectedContainers), len(results)-numberOfKindDefaultContainer)
@@ -183,7 +183,7 @@ func (suite *VertexTestSuite) TestVertexContainer() {
 }
 
 func (suite *VertexTestSuite) TestVertexNode() {
-	results, err := suite.g.V().HasLabel(vertex.NodeLabel).ElementMap().ToList()
+	results, err := suite.g.V().Has("class", vertex.NodeLabel).ElementMap().ToList()
 	suite.NoError(err)
 
 	suite.Equal(len(expectedNodes), len(results))
@@ -219,7 +219,7 @@ func (suite *VertexTestSuite) TestVertexNode() {
 }
 
 func (suite *VertexTestSuite) TestVertexPod() {
-	results, err := suite.g.V().HasLabel(vertex.PodLabel).ElementMap().ToList()
+	results, err := suite.g.V().Has("class", vertex.PodLabel).ElementMap().ToList()
 	suite.NoError(err)
 
 	suite.Equal(len(expectedPods), len(results)-numberOfKindDefaultPod)
@@ -269,7 +269,7 @@ func (suite *VertexTestSuite) TestVertexPod() {
 
 func (suite *VertexTestSuite) TestVertexPermissionSet() {
 	results, err := suite.g.V().
-		HasLabel(vertex.PermissionSetLabel).
+		Has("class", vertex.PermissionSetLabel).
 		Has("namespace", "default").
 		Values("name").
 		ToList()
@@ -292,7 +292,7 @@ func (suite *VertexTestSuite) TestVertexPermissionSet() {
 
 func (suite *VertexTestSuite) TestVertexCritical() {
 	results, err := suite.g.V().
-		HasLabel(vertex.PermissionSetLabel).
+		Has("class", vertex.PermissionSetLabel).
 		Has("critical", true).
 		Values("role").
 		ToList()
@@ -311,45 +311,45 @@ func (suite *VertexTestSuite) TestVertexCritical() {
 }
 
 func (suite *VertexTestSuite) TestVertexVolume() {
-	results, err := suite.g.V().HasLabel(vertex.VolumeLabel).ElementMap().ToList()
+	results, err := suite.g.V().Has("class", vertex.VolumeLabel).ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(61, len(results))
 
-	results, err = suite.g.V().HasLabel(vertex.VolumeLabel).Has("sourcePath", "/proc/sys/kernel").Has("name", "nodeproc").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.VolumeLabel).Has("sourcePath", "/proc/sys/kernel").Has("name", "nodeproc").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(1, len(results))
 
-	results, err = suite.g.V().HasLabel(vertex.VolumeLabel).Has("sourcePath", "/lib/modules").Has("name", "lib-modules").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.VolumeLabel).Has("sourcePath", "/lib/modules").Has("name", "lib-modules").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Greater(len(results), 1) // Not sure why it has "6"
 
-	results, err = suite.g.V().HasLabel(vertex.VolumeLabel).Has("sourcePath", "/var/log").Has("name", "nodelog").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.VolumeLabel).Has("sourcePath", "/var/log").Has("name", "nodelog").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(len(results), 1)
 }
 
 func (suite *VertexTestSuite) TestVertexIdentity() {
-	results, err := suite.g.V().HasLabel(vertex.IdentityLabel).ElementMap().ToList()
+	results, err := suite.g.V().Has("class", vertex.IdentityLabel).ElementMap().ToList()
 	suite.NoError(err)
 	suite.Greater(len(results), 50)
 
-	results, err = suite.g.V().HasLabel(vertex.IdentityLabel).Has("name", "tokenget-sa").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.IdentityLabel).Has("name", "tokenget-sa").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(len(results), 1)
 
-	results, err = suite.g.V().HasLabel(vertex.IdentityLabel).Has("name", "impersonate-sa").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.IdentityLabel).Has("name", "impersonate-sa").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(len(results), 1)
 
-	results, err = suite.g.V().HasLabel(vertex.IdentityLabel).Has("name", "tokenlist-sa").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.IdentityLabel).Has("name", "tokenlist-sa").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(len(results), 1)
 
-	results, err = suite.g.V().HasLabel(vertex.IdentityLabel).Has("name", "pod-patch-sa").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.IdentityLabel).Has("name", "pod-patch-sa").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(len(results), 1)
 
-	results, err = suite.g.V().HasLabel(vertex.IdentityLabel).Has("name", "pod-create-sa").ElementMap().ToList()
+	results, err = suite.g.V().Has("class", vertex.IdentityLabel).Has("name", "pod-create-sa").ElementMap().ToList()
 	suite.NoError(err)
 	suite.Equal(len(results), 1)
 }


### PR DESCRIPTION
We are heavily using `labels()` for our request which are not indexed and triggered warning `Janusgraph - WARNING about iterating over all vertices after schema and indexes are created`.

So we are migrate to shift `has("class",` instead of `hasLabel("`.