### PR TITLE
Fix flags for rootcmd

### DIFF
--- a/cmd/kubehound/config.go
+++ b/cmd/kubehound/config.go
@@ -20,7 +20,7 @@ var (
 		Short: "Show the current configuration",
 		Long:  `[devOnly] Show the current configuration`,
 		PreRunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), "", true, true)
+			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), cfgFile, true, true)
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Adding datadog setup

--- a/cmd/kubehound/dumper.go
+++ b/cmd/kubehound/dumper.go
@@ -62,7 +62,7 @@ var (
 				return fmt.Errorf("dump core: %w", err)
 			}
 			// Running the ingestion on KHaaS
-			if cobraCmd.Flags().Lookup("khaas-server").Value.String() != "" {
+			if khCfg.Ingestor.API.Endpoint != "" {
 				return core.CoreClientGRPCIngest(cobraCmd.Context(), khCfg.Ingestor, khCfg.Dynamic.ClusterName, khCfg.Dynamic.RunID.String())
 			}
 

--- a/cmd/kubehound/dumper.go
+++ b/cmd/kubehound/dumper.go
@@ -77,7 +77,7 @@ var (
 		PreRunE: func(cobraCmd *cobra.Command, args []string) error {
 			viper.Set(config.CollectorFileDirectory, args[0])
 
-			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), "", true, true)
+			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), cfgFile, true, true)
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Passing the Kubehound config from viper

--- a/cmd/kubehound/dumper.go
+++ b/cmd/kubehound/dumper.go
@@ -36,7 +36,7 @@ var (
 			viper.BindPFlag(config.IngestorAPIEndpoint, cobraCmd.Flags().Lookup("khaas-server")) //nolint: errcheck
 			viper.BindPFlag(config.IngestorAPIInsecure, cobraCmd.Flags().Lookup("insecure"))     //nolint: errcheck
 
-			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), "", true, true)
+			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), cfgFile, true, true)
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// using compress feature

--- a/cmd/kubehound/ingest.go
+++ b/cmd/kubehound/ingest.go
@@ -29,7 +29,7 @@ var (
 		PreRunE: func(cobraCmd *cobra.Command, args []string) error {
 			cmd.BindFlagCluster(cobraCmd)
 
-			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), "", true, true)
+			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), cfgFile, true, true)
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Passing the Kubehound config from viper

--- a/cmd/kubehound/ingest.go
+++ b/cmd/kubehound/ingest.go
@@ -56,7 +56,7 @@ var (
 				cobraCmd.MarkFlagRequired("cluster") //nolint: errcheck
 			}
 
-			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), "", false, true)
+			return cmd.InitializeKubehoundConfig(cobraCmd.Context(), cfgFile, false, true)
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			// Passing the Kubehound config from viper

--- a/cmd/kubehound/root.go
+++ b/cmd/kubehound/root.go
@@ -76,9 +76,9 @@ var (
 )
 
 func init() {
-	rootCmd.Flags().StringVarP(&cfgFile, "config", "c", cfgFile, "application config file")
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", cfgFile, "application config file")
 
-	rootCmd.Flags().BoolVar(&skipBackend, "skip-backend", skipBackend, "skip the auto deployment of the backend stack (janusgraph, mongodb, and UI)")
+	rootCmd.PersistentFlags().BoolVar(&skipBackend, "skip-backend", skipBackend, "skip the auto deployment of the backend stack (janusgraph, mongodb, and UI)")
 
 	cmd.InitRootCmd(rootCmd)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,7 +80,6 @@ func NewKubehoundConfig(ctx context.Context, configPath string, inLine bool) *Ku
 	var cfg *KubehoundConfig
 	switch {
 	case len(configPath) != 0:
-		l.Info("Loading application configuration from file", log.String("path", configPath))
 		cfg = MustLoadConfig(ctx, configPath)
 	case inLine:
 		l.Info("Loading application from inline command")
@@ -207,10 +206,12 @@ func unmarshalConfig(v *viper.Viper) (*KubehoundConfig, error) {
 
 // NewConfig creates a new config instance from the provided file using viper.
 func NewConfig(ctx context.Context, v *viper.Viper, configPath string) (*KubehoundConfig, error) {
+	l := log.Logger(ctx)
 	// Configure default values
 	SetDefaultValues(ctx, v)
 
 	// Loading inLine config path
+	l.Info("Loading application configuration from file", log.String("path", configPath))
 	v.SetConfigType(DefaultConfigType)
 	v.SetConfigFile(configPath)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -81,7 +81,7 @@ func TestMustLoadConfig(t *testing.T) {
 				},
 				Ingestor: IngestorConfig{
 					API: IngestorAPIConfig{
-						Endpoint: "127.0.0.1:9000",
+						Endpoint: "",
 						Insecure: false,
 					},
 					Blob: &BlobConfig{
@@ -158,7 +158,7 @@ func TestMustLoadConfig(t *testing.T) {
 				},
 				Ingestor: IngestorConfig{
 					API: IngestorAPIConfig{
-						Endpoint: "127.0.0.1:9000",
+						Endpoint: "",
 						Insecure: false,
 					},
 					Blob: &BlobConfig{

--- a/pkg/config/ingestor.go
+++ b/pkg/config/ingestor.go
@@ -1,7 +1,7 @@
 package config
 
 const (
-	DefaultIngestorAPIEndpoint = "127.0.0.1:9000"
+	DefaultIngestorAPIEndpoint = ""
 	DefaultIngestorAPIInsecure = false
 	DefaultBucketName          = "" // we want to let it empty because we can easily abort if it's not configured
 	DefaultTempDir             = "/tmp/kubehound"


### PR DESCRIPTION
Fixing the following errors (persistentFlag missing):

```
kubehound --config ./configs/etc/kubehound.yaml ingest remote
11:42:57 FATAL unknown flag: --skip-backend app=kubehound
main.main
        /Users/asd/go/src/github.com/DataDog/kubehound/cmd/kubehound/main.go:16
runtime.main
        /Users/asd/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.0.darwin-arm64/src/runtime/proc.go:272
```

Also fix `kuhehound dump remote` command by triggering ingestion if khaas_server is provided through a config file or command line.