### PR TITLE
graph(): Typo in `daemonsets`

### DIFF
--- a/pkg/kubehound/graph/edge/pod_create.go
+++ b/pkg/kubehound/graph/edge/pod_create.go
@@ -121,7 +121,7 @@ func (e *PodCreate) Stream(ctx context.Context, store storedb.Provider, _ cache.
 							bson.M{"$or": bson.A{
 								bson.M{"resources": "pods"},
 								bson.M{"resources": "cronjobs"},
-								bson.M{"resources": "deamonsets"},
+								bson.M{"resources": "daemonsets"},
 								bson.M{"resources": "deployments"},
 								bson.M{"resources": "jobs"},
 								bson.M{"resources": "replicasets"},

--- a/pkg/kubehound/graph/edge/pod_patch.go
+++ b/pkg/kubehound/graph/edge/pod_patch.go
@@ -122,7 +122,7 @@ func (e *PodPatch) Stream(ctx context.Context, store storedb.Provider, _ cache.C
 							bson.M{"$or": bson.A{
 								bson.M{"resources": "pods"},
 								bson.M{"resources": "cronjobs"},
-								bson.M{"resources": "deamonsets"},
+								bson.M{"resources": "daemonsets"},
 								bson.M{"resources": "deployments"},
 								bson.M{"resources": "jobs"},
 								bson.M{"resources": "replicasets"},

--- a/pkg/kubehound/graph/edge/pod_patch_namespace.go
+++ b/pkg/kubehound/graph/edge/pod_patch_namespace.go
@@ -66,7 +66,7 @@ func (e *PodPatchNamespace) Stream(ctx context.Context, store storedb.Provider, 
 							bson.M{"$or": bson.A{
 								bson.M{"resources": "pods"},
 								bson.M{"resources": "cronjobs"},
-								bson.M{"resources": "deamonsets"},
+								bson.M{"resources": "daemonsets"},
 								bson.M{"resources": "deployments"},
 								bson.M{"resources": "jobs"},
 								bson.M{"resources": "replicasets"},


### PR DESCRIPTION
[ON-IT]: Test on some clusters if daemonsets are visible after that

## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets -->

Fix the graph building mechanism to retrieve daemonsets

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links -->

`s/deamonsets/daemonsets/g`

## Blast Radius

Might increase the number of edges (and therefore paths) by some amount, need to verify the impact on ingest/query performances