### PR TITLE
[Fix] Add resilience and logs when failing during edges insertion step

### DIFF
--- a/pkg/kubehound/graph/builder.go
+++ b/pkg/kubehound/graph/builder.go
@@ -90,6 +90,7 @@ func (b *Builder) buildEdge(ctx context.Context, label string, e edge.Builder, o
 
 // buildMutating constructs all the mutating edges in the graph database.
 func (b *Builder) buildMutating(ctx context.Context, oic *converter.ObjectIDConverter) error {
+	l := log.Logger(ctx)
 	for label, e := range b.edges.Mutating() {
 		err := b.buildEdge(ctx, label, e, oic)
 		if err != nil {
@@ -102,7 +103,7 @@ func (b *Builder) buildMutating(ctx context.Context, oic *converter.ObjectIDConv
 			// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
 			// values to the user (permissions of the users etc...)
 			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
-			// l.Errorf("Failed to create a mutating edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
+			l.Warnf("Failed to create a mutating edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead): %v", e.Name(), err)
 
 			return nil
 		}
@@ -139,7 +140,7 @@ func (b *Builder) buildSimple(ctx context.Context, oic *converter.ObjectIDConver
 				// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
 				// values to the user (permissions of the users etc...)
 				// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
-				// l.Errorf("Failed to create a simple edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
+				l.Warnf("Failed to create a simple edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead): %v", e.Name(), err)
 
 				return nil
 			}
@@ -158,6 +159,7 @@ func (b *Builder) buildSimple(ctx context.Context, oic *converter.ObjectIDConver
 
 // buildDependent constructs all the dependent edges in the graph database.
 func (b *Builder) buildDependent(ctx context.Context, oic *converter.ObjectIDConverter) error {
+	l := log.Logger(ctx)
 	for label, e := range b.edges.Dependent() {
 		err := b.buildEdge(ctx, label, e, oic)
 		if err != nil {
@@ -170,7 +172,7 @@ func (b *Builder) buildDependent(ctx context.Context, oic *converter.ObjectIDCon
 			// Since the issue might not be easy or even possible for the user to fix, we still want to be able to provide _some_
 			// values to the user (permissions of the users etc...)
 			// TODO(#ASENG-512): Add an error handling framework to accumulate all errors and display them to the user in an user friendly way
-			// l.Errorf("Failed to create a dependent edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead)", e.Name())
+			l.Warnf("Failed to create a dependent edge (type: %s). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead): %v", e.Name(), err)
 
 			return nil
 		}


### PR DESCRIPTION
If an occurs runs during the edges processing steps, we do not get any error message and the batcher stop (context canceled):

```
18:04:12 ERROR worker: context canceled context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 INFO Building edge app=kubehound label=ContainerEscapeVarLogSymlink
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR run item batcher: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
18:04:12 ERROR worker: context canceled app=kubehound dd.span_id=3255329607933268550 dd.trace_id=252869397306062657
```

So to fix, I added propagation of the errors and force flush in case of errors during the inserting process:

```
17:08:22 WARN Failed to create a simple edge (type: PermissionDiscover). The created graph will be INCOMPLETE (change `builder.stop_on_error` to abort or error instead): PERMISSION_DISCOVER edge OUT id convert: graph id cache fetch (storeID=67868bf568f9207aa9ffc5f9): no matching cache entry app=kubehound dd.span_id=8262365869638944585 dd.trace_id=8014747045721427934
```
