### PR TITLE
[Fix] Add rolebinding namespace on namespace less ServiceAccount 

### DIFF
--- a/pkg/kubehound/graph/edge/permission_discover.go
+++ b/pkg/kubehound/graph/edge/permission_discover.go
@@ -122,13 +122,6 @@ func (e *PermissionDiscover) Stream(ctx context.Context, store storedb.Provider,
 								"",
 							},
 						},
-						// service account so no namespace checks needed
-						bson.M{
-							"$eq": bson.A{
-								"$result.subjects.subject.kind",
-								"ServiceAccount",
-							},
-						},
 						// clusterrolerbinding so no namespace checks needed
 						bson.M{
 							"$eq": bson.A{

--- a/test/setup/test-cluster/attacks/IDENTITY_IMPERSONATE.yaml
+++ b/test/setup/test-cluster/attacks/IDENTITY_IMPERSONATE.yaml
@@ -27,7 +27,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: impersonate-sa
-    namespace: default
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
In some cases, k8s ServiceAccount were added without namespace, which is not possible as they have to be bound to a namespace.

The error comes from the fact that rolebinding can be set on a namespace less service account (will bound automatically bound to the rolebinding one by default).

```
k describe rolebindings rb-test --namespace test                                                        
Name:         rb-test
Labels:       app=test-app
              chart_name=test-chart
              chart_version=0.1
              service=test-svc
              team=test-team
Annotations:  helm.sh/hook: post-install,post-upgrade
Role:
  Kind:  Role
  Name:  rb-test
Subjects:
  Kind            Name                Namespace
  ----            ----                ---------
  ServiceAccount  rb-test 
```

So if encountering this usecase, we add the namespace manually to rolebinding subjects and identity (serviceAccount) entries.