### PR TITLE
Kubehound with no Docker lib dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,11 @@ generate: ## Generate code for the application
 
 .PHONY: build
 build: ## Build the application
-	go build $(BUILD_FLAGS) -o "$(or $(DESTDIR),./bin/build)/kubehound$(BINARY_EXT)" ./cmd/kubehound/
+	go build $(BUILD_FLAGS) -o "$(or $(DESTDIR),./bin/build)/kubehound$(BINARY_EXT)" -tags no_backend ./cmd/kubehound/
 
 .PHONY: binary
 binary:
-	$(BUILDX_CMD) bake binary-with-coverage
+	$(BUILDX_CMD) bake binary
 
 .PHONY: lint
 lint:

--- a/cmd/kubehound/backend.go
+++ b/cmd/kubehound/backend.go
@@ -1,16 +1,18 @@
+//go:build no_backend
+
 package main
 
 import (
-	docker "github.com/DataDog/KubeHound/pkg/backend"
+	"github.com/DataDog/KubeHound/pkg/backend"
 	"github.com/spf13/cobra"
 )
 
 var (
-	Backend     *docker.Backend
+	Backend     *backend.Backend
 	hard        bool
 	composePath []string
 
-	uiProfile = docker.DefaultUIProfile
+	uiProfile = backend.DefaultUIProfile
 	uiInvana  bool
 )
 
@@ -24,7 +26,7 @@ var (
 				uiProfile = append(uiProfile, "invana")
 			}
 
-			return docker.NewBackend(cobraCmd.Context(), composePath, uiProfile)
+			return backend.NewBackend(cobraCmd.Context(), composePath, uiProfile)
 		},
 	}
 
@@ -33,7 +35,7 @@ var (
 		Short: "Spawn the kubehound stack",
 		Long:  `Spawn the kubehound stack`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return docker.Up(cobraCmd.Context())
+			return backend.Up(cobraCmd.Context())
 		},
 	}
 
@@ -42,7 +44,7 @@ var (
 		Short: "Wipe the persisted backend data",
 		Long:  `Wipe the persisted backend data`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return docker.Wipe(cobraCmd.Context())
+			return backend.Wipe(cobraCmd.Context())
 		},
 	}
 
@@ -51,7 +53,7 @@ var (
 		Short: "Tear down the kubehound stack",
 		Long:  `Tear down the kubehound stack`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return docker.Down(cobraCmd.Context())
+			return backend.Down(cobraCmd.Context())
 		},
 	}
 
@@ -60,19 +62,19 @@ var (
 		Short: "Restart the kubehound stack",
 		Long:  `Restart the kubehound stack`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			err := docker.Down(cobraCmd.Context())
+			err := backend.Down(cobraCmd.Context())
 			if err != nil {
 				return err
 			}
 
 			if hard {
-				err = docker.Wipe(cobraCmd.Context())
+				err = backend.Wipe(cobraCmd.Context())
 				if err != nil {
 					return err
 				}
 			}
 
-			return docker.Reset(cobraCmd.Context())
+			return backend.Reset(cobraCmd.Context())
 		},
 	}
 )

--- a/cmd/kubehound/dev.go
+++ b/cmd/kubehound/dev.go
@@ -1,3 +1,5 @@
+//go:build no_backend
+
 package main
 
 import (
@@ -5,7 +7,6 @@ import (
 	"os"
 
 	"github.com/DataDog/KubeHound/pkg/backend"
-	docker "github.com/DataDog/KubeHound/pkg/backend"
 	"github.com/spf13/cobra"
 )
 
@@ -64,15 +65,15 @@ func runEnv(ctx context.Context, composePaths []string) error {
 		profiles = append(profiles, backend.DevUIProfile)
 	}
 
-	err := docker.NewBackend(ctx, composePaths, profiles)
+	err := backend.NewBackend(ctx, composePaths, profiles)
 	if err != nil {
 		return err
 	}
 	if downTesting {
-		return docker.Down(ctx)
+		return backend.Down(ctx)
 	}
 
-	return docker.BuildUp(ctx, noCache)
+	return backend.BuildUp(ctx, noCache)
 }
 
 func init() {

--- a/cmd/kubehound/dumper.go
+++ b/cmd/kubehound/dumper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	docker "github.com/DataDog/KubeHound/pkg/backend"
 	"github.com/DataDog/KubeHound/pkg/cmd"
 	"github.com/DataDog/KubeHound/pkg/config"
 	"github.com/DataDog/KubeHound/pkg/kubehound/core"
@@ -91,13 +90,9 @@ var (
 			}
 
 			if startBackend {
-				err = docker.NewBackend(cobraCmd.Context(), composePath, docker.DefaultUIProfile)
+				err = runBackendCompose(cobraCmd.Context())
 				if err != nil {
-					return fmt.Errorf("new backend: %w", err)
-				}
-				err = docker.Up(cobraCmd.Context())
-				if err != nil {
-					return fmt.Errorf("docker up: %w", err)
+					return err
 				}
 			}
 

--- a/cmd/kubehound/root.go
+++ b/cmd/kubehound/root.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/DataDog/KubeHound/pkg/backend"
 	"github.com/DataDog/KubeHound/pkg/cmd"
 	"github.com/DataDog/KubeHound/pkg/kubehound/core"
 	"github.com/DataDog/KubeHound/pkg/telemetry/log"
@@ -27,22 +26,9 @@ var (
 			l := log.Logger(cobraCmd.Context())
 			// auto spawning the backend stack
 			if !skipBackend {
-				// Forcing the embed docker config to be loaded
-				err := backend.NewBackend(cobraCmd.Context(), []string{""}, backend.DefaultUIProfile)
+				err := runBackend(cobraCmd.Context())
 				if err != nil {
 					return err
-				}
-				res, err := backend.IsStackRunning(cobraCmd.Context())
-				if err != nil {
-					return err
-				}
-				if !res {
-					err = backend.Up(cobraCmd.Context())
-					if err != nil {
-						return err
-					}
-				} else {
-					l.Info("Backend stack is already running")
 				}
 			}
 

--- a/cmd/kubehound/util_default.go
+++ b/cmd/kubehound/util_default.go
@@ -1,0 +1,23 @@
+//go:build !no_backend
+
+package main
+
+import (
+	"context"
+
+	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+)
+
+func runBackend(ctx context.Context) error {
+	l := log.Logger(ctx)
+	l.Warn("Backend is not supported in this build")
+
+	return nil
+}
+
+func runBackendCompose(ctx context.Context) error {
+	l := log.Logger(ctx)
+	l.Warn("Backend is not supported in this build")
+
+	return nil
+}

--- a/cmd/kubehound/util_no_backend.go
+++ b/cmd/kubehound/util_no_backend.go
@@ -1,0 +1,48 @@
+//go:build no_backend
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/KubeHound/pkg/backend"
+	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+)
+
+func runBackend(ctx context.Context) error {
+	l := log.Logger(ctx)
+
+	// Forcing the embed docker config to be loaded
+	err := backend.NewBackend(ctx, []string{""}, backend.DefaultUIProfile)
+	if err != nil {
+		return err
+	}
+	res, err := backend.IsStackRunning(ctx)
+	if err != nil {
+		return err
+	}
+	if !res {
+		err = backend.Up(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+		l.Info("Backend stack is already running")
+	}
+
+	return nil
+}
+
+func runBackendCompose(ctx context.Context) error {
+	err := backend.NewBackend(ctx, composePath, backend.DefaultUIProfile)
+	if err != nil {
+		return fmt.Errorf("new backend: %w", err)
+	}
+	err = backend.Up(ctx)
+	if err != nil {
+		return fmt.Errorf("docker up: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/backend/containers.go
+++ b/pkg/backend/containers.go
@@ -1,3 +1,5 @@
+//go:build no_backend
+
 package backend
 
 import (

--- a/pkg/backend/project.go
+++ b/pkg/backend/project.go
@@ -1,3 +1,5 @@
+//go:build no_backend
+
 package backend
 
 import (

--- a/pkg/backend/util.go
+++ b/pkg/backend/util.go
@@ -1,3 +1,5 @@
+//go:build no_backend
+
 package backend
 
 func mergeMaps(currentMap map[interface{}]interface{}, newMap map[interface{}]interface{}) map[interface{}]interface{} {


### PR DESCRIPTION
Docker dependencies are "heavy" and implies CGO complexity.

Adding a specific tag `no_backend` to build a version which is docker free (without specificying this tag, kubehound will be built without docker dependencies).