### PR TITLE
[Fix] Invalid character in build-binary CI job

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
-          name: kubehound-${{ matrix.platform }}
+          name: kubehound-${{ env.PLATFORM_PAIR }}
           path: ./bin/release/*
           if-no-files-found: error
 


### PR DESCRIPTION
Fix artifact name with forbidden character (`/`)