### PR TITLE
[Fix] missing artifacts in build-binaries CI job

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: kubehound-${{ env.PLATFORM_PAIR }}
-          path: ./bin/release/*
+          path: ./bin/release
           if-no-files-found: error
 
   release:
@@ -91,10 +91,11 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: kubehound
-          path: bin/release
+          name: kubehound-*
+          path: ./bin/release
+          merge-multiple: true
       - name: Create checksums
-        working-directory: bin/release
+        working-directory: ./bin/release
         run: |
           find . -type f -print0 | sort -z | xargs -r0 shasum -a 256 -b | sed 's# \*\./# *#' > $RUNNER_TEMP/checksums.txt
           shasum -a 256 -U -c $RUNNER_TEMP/checksums.txt
@@ -102,15 +103,15 @@ jobs:
           cat checksums.txt | while read sum file; do echo "$sum $file" > ${file#\*}.sha256; done
       - name: List artifacts
         run: |
-          tree -nh bin/release
+          tree -nh ./bin/release
       - name: Check artifacts
         run: |
-          find bin/release -type f -exec file -e ascii -- {} +
+          find ./bin/release -type f -exec file -e ascii -- {} +
       - name: GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:
-          artifacts: bin/release/*
+          artifacts: ./bin/release/*
           generateReleaseNotes: true
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix missing artifacts in build-binaries CI job

```
Error: Unable to download artifact(s): Artifact not found for name: kubehound
```