### PR TITLE
[Fix] checkout v4 release missing artifact

### DIFF
--- a/.github/workflows/buildx.yml
+++ b/.github/workflows/buildx.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: kubehound-*
+          pattern: kubehound-*
           path: ./bin/release
           merge-multiple: true
       - name: Create checksums


### PR DESCRIPTION
Fix missing artifacts in build-binaries CI job

```
Error: Unable to download artifact(s): Artifact not found for name: kubehound
```