### PR TITLE
(doc) More precise installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ To run KubeHound, you need a couple dependencies
 + [Docker](https://docs.docker.com/engine/install/) `>= 19.03` 
 + [Docker Compose](https://docs.docker.com/compose/compose-file/compose-versioning/) `V2`
 
-### Install and run
+### Install
 
-Select a target Kubernetes cluster, either:
-* Using [kubectx](https://github.com/ahmetb/kubectx)
-* Using specific kubeconfig file by exporting the env variable: `export KUBECONFIG=/your/path/to/.kube/config`
+#### From Release
 
 Download binaries are available for Linux / Windows / Mac OS via the [releases](https://github.com/DataDog/KubeHound/releases) page or by running the following (Mac OS/Linux):
 ```bash
@@ -32,10 +30,43 @@ If downloading the releases via a browser you must run e.g `xattr -d com.apple.q
 
 </details>
 
+#### With homebrew
 
-Then, simply run
+KubeHound is available in homebrew-core and you can simply run
 ```bash
+brew update && brew install kubehound
+```
+
+`kubehound` should now be in your path.
+
+#### From source
+
+If you wish to build KubeHound from source, you will need to checkout a tag before building
+```bash
+git clone https://github.com/DataDog/KubeHound.git
+cd KubeHound
+git checkout $(git describe --tags --abbrev=0)
+make build
+```
+
+KubeHound binary will be output to `./bin/build/kubehound`.
+
+### Run
+
+Select a target Kubernetes cluster, either:
+* Using [kubectx](https://github.com/ahmetb/kubectx)
+* Using specific kubeconfig file by exporting the env variable: `export KUBECONFIG=/your/path/to/.kube/config`
+
+Then, simply run the `kubehound` binary:
+```bash
+# If you installed it from brew, it is in your path
+kubehound
+
+# If you installed it from release, it should be were you downloaded it
 ./kubehound
+
+# If you installed it from source, it should be in the <repo_path>/bin/build folder
+./bin/build/kubehound
 ```
 
 For more advanced use case and configuration, see 

--- a/docs/dev-guide/getting-started.md
+++ b/docs/dev-guide/getting-started.md
@@ -68,6 +68,11 @@ make build
     to spin up the KubeHound stack. You should use a release tag to build the binary or
     use the `kubehound dev` command to spin up the dev stack.
 
+!!! note
+
+    Being on a commit older than the latest one will also pull older images, to avoid dependency incompatibility.
+    We strongly advise to use the latest tag to enjoy all features and performance improvements.
+
 KubeHound binary will be output to `./bin/build/kubehound`.
 
 ### Releases

--- a/docs/dev-guide/getting-started.md
+++ b/docs/dev-guide/getting-started.md
@@ -56,8 +56,17 @@ kubehound dev --down
 To build KubeHound locally from the sources, use the Makefile:
 
 ```bash
+# Ensure you are pulling a release tag
+git checkout tags/vX.X.X
+# Build the binary
 make build
 ```
+
+!!! note
+
+    While building the binary using a `main` revision, the binary will not be able 
+    to spin up the KubeHound stack. You should use a release tag to build the binary or
+    use the `kubehound dev` command to spin up the dev stack.
 
 KubeHound binary will be output to `./bin/build/kubehound`.
 

--- a/pkg/backend/project.go
+++ b/pkg/backend/project.go
@@ -123,9 +123,9 @@ func loadEmbeddedDockerCompose(ctx context.Context, filepath string, dockerCompo
 		// Setting the version tag for the release dynamically
 		version := map[string]string{"VersionTag": config.BuildVersion}
 
-		// For local version (when the version is "dirty", using latest to have a working binary)
-		// For any branch outside of main, using latest image as the current tag will cover (including the commit sha in the tag)
-		if strings.HasSuffix(config.BuildBranch, "dirty") || config.BuildBranch != "main" {
+		// If we are on a detached commit, we are probably on a release tag and git rev-parse --abbrev-ref HEAD will return "HEAD"
+		// For any branch outside of main and the detached states, using latest image as the current tag will cover (including the commit sha in the tag)
+		if config.BuildBranch != "main" && config.BuildBranch != "HEAD" {
 			l.Warn("Loading the kubehound images with tag latest - dev branch detected")
 			version["VersionTag"] = "latest"
 		}


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets -->

Address #326 : building the image from source should not be done straight from main as changes on main are not "pushed" to the registries until a new tag is created, but instead it should be done at a specific tagged commit

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links -->

- Add checkout instructions in dev-guide
- Add checkout instructions in README
- Add homebrew instructions in README
- In the docker tag selector function, prevent overriding the build tag with "latest" if we are on a detached commit (which is the case when building from a release tag)
