### PR TITLE
feat(profile): register Go profile exports flags.

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -83,6 +83,6 @@ jobs:
         run: sleep 30
 
       - name: Run integration Tests
-        run: cd test/system && export KUBECONFIG=$(ROOT_DIR)/test/setup/${KIND_KUBECONFIG} && go test -v -timeout "180s" -count=1 -race ./...
+        run: make system-test-fast
         env:
-          KIND_KUBECONFIG: .kube-config
+          KIND_KUBECONFIG: ./test/setup/.kube-config

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -85,4 +85,4 @@ jobs:
       - name: Run integration Tests
         run: make system-test-fast
         env:
-          KIND_KUBECONFIG: ./test/setup/.kube-config
+          KIND_KUBECONFIG: .kube-config

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -75,3 +75,9 @@ jobs:
         run: make system-test
         env:
           KIND_KUBECONFIG: .kube-config
+
+      - name: Dump JanusGraph Logs
+        run: docker logs kubehound-testing-kubegraph-1
+
+      - name: Dump MongoDB Logs
+        run: docker logs kubehound-testing-mongodb-1

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -72,12 +72,9 @@ jobs:
           go-version: "1.23"
 
       - name: Run integration Tests
-        run: make system-test
+        run: |-
+          make system-test
+          docker logs kubehound-testing-kubegraph-1
+          docker logs kubehound-testing-mongodb-1
         env:
           KIND_KUBECONFIG: .kube-config
-
-      - name: Dump JanusGraph Logs
-        run: docker logs kubehound-testing-kubegraph-1
-
-      - name: Dump MongoDB Logs
-        run: docker logs kubehound-testing-mongodb-1

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -71,10 +71,18 @@ jobs:
         with:
           go-version: "1.23"
 
+      - name: Build Kubehound
+        run: make build
+      
+      - name: Deploy test environment
+        run: ./bin/build/kubehound dev system-tests
+        env:
+          KUBECONFIG: ./test/setup/.kube-config
+
+      - name: Pause for 30 seconds
+        run: sleep 30
+
       - name: Run integration Tests
-        run: |-
-          make system-test
-          docker logs kubehound-testing-kubegraph-1
-          docker logs kubehound-testing-mongodb-1
+        run: cd test/system && export KUBECONFIG=$(ROOT_DIR)/test/setup/${KIND_KUBECONFIG} && go test -v -timeout "180s" -count=1 -race ./...
         env:
           KIND_KUBECONFIG: .kube-config

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test: ## Run the full suite of unit tests
 .PHONY: system-test
 system-test: | build ## Run the system tests
 	./bin/build/kubehound dev system-tests
-	cd test/system && export KUBECONFIG=$(ROOT_DIR)/test/setup/${KIND_KUBECONFIG} && go test -v -timeout "120s" -count=1 -race ./...
+	cd test/system && export KUBECONFIG=$(ROOT_DIR)/test/setup/${KIND_KUBECONFIG} && go test -v -timeout "180s" -count=1 -race ./...
 
 .PHONY: system-test-fast
 system-test-fast: ## Run the system tests WITHOUT recreating the backend

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ system-test: | build ## Run the system tests
 
 .PHONY: system-test-fast
 system-test-fast: ## Run the system tests WITHOUT recreating the backend
-	cd test/system && export KUBECONFIG=$(ROOT_DIR)/test/setup/${KIND_KUBECONFIG} && go test -v -timeout "60s" -count=1 -race ./...
+	cd test/system && export KUBECONFIG=$(ROOT_DIR)/test/setup/${KIND_KUBECONFIG} && go test -v -timeout "120s" -count=1 -race ./...
 
 .PHONY: system-test-clean
 system-test-clean: | build ## Tear down the kubehound stack for the system-test

--- a/cmd/kubehound/main.go
+++ b/cmd/kubehound/main.go
@@ -1,9 +1,11 @@
 package main
 
-import "os"
+import (
+	"github.com/DataDog/KubeHound/pkg/telemetry/log"
+)
 
 func main() {
 	if err := Execute(); err != nil {
-		os.Exit(1)
+		log.DefaultLogger().Fatal("unable to execute command", log.ErrorField(err))
 	}
 }

--- a/cmd/kubehound/main.go
+++ b/cmd/kubehound/main.go
@@ -1,18 +1,9 @@
 package main
 
-import (
-	"errors"
-
-	"github.com/DataDog/KubeHound/pkg/cmd"
-	"github.com/DataDog/KubeHound/pkg/telemetry/log"
-	"github.com/DataDog/KubeHound/pkg/telemetry/tag"
-)
+import "os"
 
 func main() {
-	tag.SetupBaseTags()
-	err := rootCmd.Execute()
-	err = errors.Join(err, cmd.CloseKubehoundConfig(rootCmd.Context()))
-	if err != nil {
-		log.Logger(rootCmd.Context()).Fatal(err.Error())
+	if err := Execute(); err != nil {
+		os.Exit(1)
 	}
 }

--- a/cmd/kubehound/root.go
+++ b/cmd/kubehound/root.go
@@ -68,6 +68,7 @@ var (
 		},
 		PersistentPostRunE: func(cobraCmd *cobra.Command, _ []string) error {
 			defer rootPostRun(cobraCmd.Context())
+
 			return cmd.CloseKubehoundConfig(cobraCmd.Context())
 		},
 		SilenceUsage:  true,
@@ -121,6 +122,7 @@ func startCPUProfile(l log.LoggerI) error {
 		if err := f.Close(); err != nil {
 			l.Error("error while closing cpu profile file", log.ErrorField(err))
 		}
+
 		return err
 	}
 
@@ -182,16 +184,17 @@ func rootPostRun(ctx context.Context) {
 		writeProfile := func(profileName string, profile *pprof.Profile) {
 			file, err := os.Create(path.Clean(memProfile + profileName))
 			if err != nil {
-				l.Error(fmt.Sprintf("error while creating mem-profile %s file", profileName), log.ErrorField(err))
+				l.With(log.ErrorField(err)).Errorf("error while creating mem-profile %s file", profileName)
+
 				return
 			}
 			defer func() {
 				if err := file.Close(); err != nil {
-					l.Error(fmt.Sprintf("error while closing mem-profile %s file", profileName), log.ErrorField(err))
+					l.With(log.ErrorField(err)).Errorf("error while closing mem-profile %s file", profileName)
 				}
 			}()
 			if err := profile.WriteTo(file, 0); err != nil {
-				l.Error(fmt.Sprintf("error while writing mem-profile %s profile", profileName), log.ErrorField(err))
+				l.With(log.ErrorField(err)).Errorf("error while writing mem-profile %s profile", profileName)
 			}
 		}
 

--- a/cmd/kubehound/root.go
+++ b/cmd/kubehound/root.go
@@ -216,7 +216,7 @@ func rootPostRun(ctx context.Context) {
 // Execute the root command.
 func Execute() error {
 	tag.SetupBaseTags()
-	
+
 	return rootCmd.Execute()
 }
 

--- a/cmd/kubehound/root.go
+++ b/cmd/kubehound/root.go
@@ -216,6 +216,7 @@ func rootPostRun(ctx context.Context) {
 // Execute the root command.
 func Execute() error {
 	tag.SetupBaseTags()
+	
 	return rootCmd.Execute()
 }
 


### PR DESCRIPTION
# Context

Register Go profiling export flags to allow developers to debug runtime issues.

* `--mem-profile` exports `allocs`, `heap` and `goroutine` in dedicated files. The user has to provide a file path, and each profile will be exported in a file with profile type suffix.
* `--cpu-profile` exports `cpu` profile information used to debug performance/computation issues.
* `--block-profile` exports `block` profile information used to understand how much time your program spending waiting for blocking operation.

# Reference(s)

- https://go.dev/blog/pprof