### PR TITLE
fix(cli): add a newline to version output.

### DIFF
--- a/cmd/kubehound/version.go
+++ b/cmd/kubehound/version.go
@@ -14,7 +14,7 @@ var (
 		Short: "print Kubehound version",
 		Long:  `print the current version of Kubehound`,
 		Run: func(cobraCmd *cobra.Command, args []string) {
-			fmt.Printf("kubehound version: %s (%s/%s)", config.BuildVersion, config.BuildArch, config.BuildOs) //nolint:forbidigo
+			fmt.Printf("kubehound version: %s (%s/%s)\n", config.BuildVersion, config.BuildArch, config.BuildOs) //nolint:forbidigo
 		},
 		PersistentPostRun: func(cobraCmd *cobra.Command, args []string) {
 			os.Exit(0)


### PR DESCRIPTION
# Context

Append a newline character at the end of the `kh version` output.

# Reference(s)

- fix https://github.com/DataDog/KubeHound/issues/335