### PR TITLE
[DRAFT] Skip one log caller level on tracer wrapper

### DIFF
--- a/pkg/kubehound/core/core_dump.go
+++ b/pkg/kubehound/core/core_dump.go
@@ -44,6 +44,7 @@ func DumpCore(ctx context.Context, khCfg *config.KubehoundConfig, upload bool) (
 	span, ctx := span.SpanRunFromContext(ctx, span.DumperLaunch)
 	span.SetTag(ext.ManualKeep, true)
 	l = log.Logger(ctx)
+	l.Skip(1)
 	defer func() {
 		span.Finish(tracer.WithError(err))
 	}()

--- a/pkg/telemetry/log/logger.go
+++ b/pkg/telemetry/log/logger.go
@@ -34,6 +34,8 @@ type LoggerI interface { //nolint: interfacebloat
 	Errorf(msg string, params ...interface{})
 	Panicf(msg string, params ...interface{})
 	Fatalf(msg string, params ...interface{})
+
+	Skip(skip int)
 }
 
 type KubehoundLogger struct {

--- a/pkg/telemetry/log/trace_logger.go
+++ b/pkg/telemetry/log/trace_logger.go
@@ -144,3 +144,7 @@ func (t *traceLogger) Panicf(msg string, params ...interface{}) {
 func (t *traceLogger) Fatalf(msg string, params ...interface{}) {
 	t.logger.With(t.fields...).Fatalf(msg, params...)
 }
+
+func (t *traceLogger) Skip(skip int) {
+	t.logger.Skip(skip)
+}

--- a/pkg/telemetry/log/zap_logger.go
+++ b/pkg/telemetry/log/zap_logger.go
@@ -65,3 +65,7 @@ func (z *zapLogger) Panicf(msg string, params ...interface{}) {
 func (z *zapLogger) Fatalf(msg string, params ...interface{}) {
 	z.s.Fatalf(msg, params...)
 }
+
+func (z *zapLogger) Skip(skip int) {
+	z.l = z.l.WithOptions(zap.AddCallerSkip(skip))
+}


### PR DESCRIPTION
## Motivation

<!-- Why are you making this change, what problem does it solve? Include links to relevant tickets -->

When running locally, no problem with the logger.

When running KubeHound as a Service with telemetry enabled, the logger is wrapped in the TraceLogger which adds a level of bubbling making the caller appear as `log/trace_logger.go:101`:
<img width="512" height="278" alt="image" src="https://github.com/user-attachments/assets/67013785-f5e6-455d-b3e4-7c6c64b263e1" />

## Changes

<!-- What does this change exactly? Who will be affected? Include relevant screenshots, videos, links -->

Add a `Skip` function to skip a level when adding a log layer.

This might not be the good way to implement it, we may want to put it in the `InitTelemetry` function or something.

## QA Instructions

<!-- How can the reviewer confirm these changes do what you say they do? Include links to staging/static_hashes with instructions -->

## Blast Radius

<!-- What areas of the application are impacted by this PR? Are there feature flags that narrow the scope of customer impact? How risky is this particular changeset? -->

<!-- This is really useful information for anyone who is handling an incident. It provides a quick way to identify PRs that might be related. -->

## Documentation
