### PR TITLE
fix: correct argument order in sanitizeExtractPath to prevent Zip Slip

### DIFF
--- a/pkg/ingestor/puller/puller.go
+++ b/pkg/ingestor/puller/puller.go
@@ -94,7 +94,7 @@ func ExtractTarGz(ctx context.Context, checkOnly bool, archivePath string, baseP
 			return err
 		}
 
-		err = sanitizeExtractPath(basePath, header.Name)
+		err = sanitizeExtractPath(header.Name, basePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/ingestor/puller/puller_test.go
+++ b/pkg/ingestor/puller/puller_test.go
@@ -27,24 +27,6 @@ func Test_sanitizeExtractPath(t *testing.T) {
 			args:    args{filePath: "../../test", destination: "/tmp"},
 			wantErr: true,
 		},
-		// Regression tests for Zip Slip: swapped arguments at the call site previously
-		// caused sanitizeExtractPath to always pass for any header.Name value, allowing
-		// path-traversal entries in a malicious archive to write to arbitrary locations.
-		{
-			name:    "Zip Slip: traversal to /etc/passwd is blocked",
-			args:    args{filePath: "../../../etc/passwd", destination: "/tmp/kubehound/kh-abc123"},
-			wantErr: true,
-		},
-		{
-			name:    "Zip Slip: traversal to ssh authorized_keys is blocked",
-			args:    args{filePath: "../../root/.ssh/authorized_keys", destination: "/tmp/kubehound/kh-abc123"},
-			wantErr: true,
-		},
-		{
-			name:    "Zip Slip: legitimate nested path is allowed",
-			args:    args{filePath: "pods/pods.json", destination: "/tmp/kubehound/kh-abc123"},
-			wantErr: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ingestor/puller/puller_test.go
+++ b/pkg/ingestor/puller/puller_test.go
@@ -27,6 +27,24 @@ func Test_sanitizeExtractPath(t *testing.T) {
 			args:    args{filePath: "../../test", destination: "/tmp"},
 			wantErr: true,
 		},
+		// Regression tests for Zip Slip: swapped arguments at the call site previously
+		// caused sanitizeExtractPath to always pass for any header.Name value, allowing
+		// path-traversal entries in a malicious archive to write to arbitrary locations.
+		{
+			name:    "Zip Slip: traversal to /etc/passwd is blocked",
+			args:    args{filePath: "../../../etc/passwd", destination: "/tmp/kubehound/kh-abc123"},
+			wantErr: true,
+		},
+		{
+			name:    "Zip Slip: traversal to ssh authorized_keys is blocked",
+			args:    args{filePath: "../../root/.ssh/authorized_keys", destination: "/tmp/kubehound/kh-abc123"},
+			wantErr: true,
+		},
+		{
+			name:    "Zip Slip: legitimate nested path is allowed",
+			args:    args{filePath: "pods/pods.json", destination: "/tmp/kubehound/kh-abc123"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

`sanitizeExtractPath` was called with its arguments transposed at the call site in `ExtractTarGz` (line 97). With the arguments swapped, `destination` received the attacker-controlled `header.Name` value, causing the `HasPrefix` check to always pass and rendering the Zip Slip guard completely ineffective.

**Buggy call (before):**
```go
err = sanitizeExtractPath(basePath, header.Name)
// filePath    = basePath     ← safe, fixed directory
// destination = header.Name  ← attacker-controlled tar entry
```

**Fixed call (after):**
```go
err = sanitizeExtractPath(header.Name, basePath)
```

With the swapped arguments, `destination` received the attacker-controlled string, so the check evaluated:
```
destpath   = Join("../../../etc/passwd", "/tmp/kubehound/kh-abc123")
           = "../../../etc/passwd/tmp/kubehound/kh-abc123"
clean_dest = "../../../etc/passwd/"
HasPrefix? = TRUE  ← always passes, for ANY header.Name value
```

The `//nolint:gosec` comment on the `filepath.Join` call immediately below suppressed the only other guard.

## Impact

A malicious `.tar.gz` archive with path-traversal entry names (e.g. `../../../etc/passwd`, `../../root/.ssh/authorized_keys`) bypasses the safety check and writes to arbitrary locations on the host filesystem with the privileges of the KubeHound process — enabling SSH key injection or persistent access.

Attack vectors:
1. Write access to the configured blob store (S3, GCS, Azure Blob, local path)
2. Unauthenticated gRPC endpoint (`grpc.NewServer()` with no auth interceptors or TLS)

## References
- https://security.snyk.io/research/zip-slip-vulnerability
- CWE-22: https://cwe.mitre.org/data/definitions/22.html